### PR TITLE
remove download of java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 sudo: required
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
 
 language: java
 


### PR DESCRIPTION
It seems there is problem with the download URL used by Travis.

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
link to downloading java 8 in Travis not working

### Description of the Change
remove requirement to download java 8

### Alternate Designs
None

### Benefits
None

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Vasile Baluta, vasile.baluta@ericsson.com
