### PR TITLE
Fix auth-behaviour

### DIFF
--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/bulk/SubscriptionBulkSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/bulk/SubscriptionBulkSteps.java
@@ -1,5 +1,17 @@
 package com.ericsson.ei.subscriptions.bulk;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.apache.commons.io.FileUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Ignore;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
 import com.ericsson.ei.controller.model.GetSubscriptionResponse;
 import com.ericsson.ei.utils.FunctionalTestBase;
 import com.ericsson.ei.utils.HttpRequest;
@@ -9,17 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-import org.apache.commons.io.FileUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.junit.Ignore;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.TestPropertySource;
-
-import java.io.File;
-
-import static org.junit.Assert.assertEquals;
 
 @Ignore
 @TestPropertySource(properties = {"logging.level.com.ericsson.ei.subscriptions.bulk=DEBUG"})
@@ -138,7 +139,7 @@ public class SubscriptionBulkSteps extends FunctionalTestBase {
                     retrievedSubscriptions.getJSONObject(i).get("notificationType"));
             assertEquals(subscriptions.getJSONObject(i).get("notificationMeta"),
                     retrievedSubscriptions.getJSONObject(i).get("notificationMeta"));
-            assertEquals(true, retrievedSubscriptions.getJSONObject(i).has("userName"));
+            assertEquals(true, retrievedSubscriptions.getJSONObject(i).has("ldapUserName"));
         }
     }
 }

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/trigger/SubscriptionTriggerSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/trigger/SubscriptionTriggerSteps.java
@@ -1,14 +1,18 @@
 package com.ericsson.ei.subscriptions.trigger;
 
-import com.dumbster.smtp.SimpleSmtpServer;
-import com.dumbster.smtp.SmtpMessage;
-import com.ericsson.ei.utils.FunctionalTestBase;
-import com.ericsson.ei.utils.HttpRequest;
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.io.FileUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -26,18 +30,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.util.SocketUtils;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import com.dumbster.smtp.SimpleSmtpServer;
+import com.dumbster.smtp.SmtpMessage;
+import com.ericsson.ei.utils.FunctionalTestBase;
+import com.ericsson.ei.utils.HttpRequest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 
 @Ignore
 public class SubscriptionTriggerSteps extends FunctionalTestBase {
@@ -276,7 +278,7 @@ public class SubscriptionTriggerSteps extends FunctionalTestBase {
         mockClient = new MockServerClient(getHostName(), port);
         mockClient.when(request().withMethod("POST").withPath(REST_ENDPOINT)).respond(response().withStatusCode(201));
         mockClient.when(request().withMethod("POST").withPath(REST_ENDPOINT_AUTH)
-                .withHeader("Authorization", "Basic TXkgbW90aGVyIGhhcyAyIGNhdHMgYW5kIHRoZXkgYXJlIGNyYXp5"))
+                .withHeader("Authorization", "Basic bXlVc2VyTmFtZTpteVBhc3N3b3Jk"))
                 .respond(response().withStatusCode(201));
         mockClient.when(request().withMethod("POST").withPath(REST_ENDPOINT_PARAMS))
                 .respond(response().withStatusCode(201));

--- a/src/functionaltests/resources/subscription_multiple.json
+++ b/src/functionaltests/resources/subscription_multiple.json
@@ -1,7 +1,7 @@
 [
   {
     "subscriptionName": "Subscription_Mail",
-    "userName": "DEF",
+    "ldapUserName": "DEF",
     "repeat": false,
     "created": "data-time",
     "notificationType": "MAIL",
@@ -32,7 +32,7 @@
   },
   {
     "subscriptionName": "Subscription_Rest_Params_in_Head",
-    "userName": "DEF",
+    "ldapUserName": "DEF",
     "repeat": false,
     "created": "data-time",
     "notificationType": "REST_POST",
@@ -63,7 +63,10 @@
   },
   {
     "subscriptionName": "Subscription_Rest_Auth_Params_in_Head",
-    "userName": "DEF",
+    "ldapUserName": "DEF",
+    "userName": "myUserName",
+    "password": "myPassword",
+    "authenticationType": "BASIC_AUTH",
     "repeat": false,
     "created": "data-time",
     "notificationType": "REST_POST",
@@ -74,10 +77,6 @@
       {
         "formkey" : "json",
         "formvalue" : "{parameter: [{ id: testCaseExecutions[0].outcome.id, value : testCaseExecutions[0].outcome.conclusion }]}"
-      },
-      {
-        "formkey" : "Authorization",
-        "formvalue" : "Basic TXkgbW90aGVyIGhhcyAyIGNhdHMgYW5kIHRoZXkgYXJlIGNyYXp5"
       }
     ],
 
@@ -101,7 +100,7 @@
   },
   {
     "subscriptionName": "Subscription_Rest_Params_in_Url",
-    "userName": "DEF",
+    "ldapUserName": "DEF",
     "repeat": false,
     "created": "data-time",
     "notificationType": "REST_POST",
@@ -126,7 +125,7 @@
   },
   {
     "subscriptionName": "Subscription_Rest_Auth_Params_in_Url",
-    "userName": "DEF",
+    "ldapUserName": "DEF",
     "repeat": false,
     "created": "data-time",
     "notificationType": "REST_POST",
@@ -152,7 +151,7 @@
   },
   {
     "subscriptionName": "Subscription_Row_Body",
-    "userName": "DEF",
+    "ldapUserName": "DEF",
     "repeat": false,
     "created": "data-time",
     "notificationType": "REST_POST",

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionController.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionController.java
@@ -3,7 +3,6 @@ package com.ericsson.ei.controller;
 
 import java.util.List;
 import javax.validation.Valid;
-import com.ericsson.ei.controller.model.GetSubscriptionResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,20 +33,20 @@ public interface SubscriptionController {
      * 
      */
     @RequestMapping(value = "", method = RequestMethod.POST)
-    public ResponseEntity<List<com.ericsson.ei.controller.model.SubscriptionResponse>> createSubscription(
+    public ResponseEntity<List<String>> createSubscription(
         @Valid
         @RequestBody
-        List<com.ericsson.ei.controller.model.Subscription> subscription);
+        List<String> string);
 
     /**
      * Modify existing Subscriptions.
      * 
      */
     @RequestMapping(value = "", method = RequestMethod.PUT)
-    public ResponseEntity<List<com.ericsson.ei.controller.model.SubscriptionResponse>> updateSubscriptions(
+    public ResponseEntity<List<String>> updateSubscriptions(
         @Valid
         @RequestBody
-        List<com.ericsson.ei.controller.model.Subscription> subscription);
+        List<String> string);
 
     /**
      * Returns the subscriptions for the given subscription names.
@@ -56,15 +55,15 @@ public interface SubscriptionController {
     @RequestMapping(value = "/{subscriptionNames}", method = RequestMethod.GET)
     public ResponseEntity<GetSubscriptionResponse> getSubscriptionById(
         @PathVariable
-        String subscriptionNames);
+        java.lang.String subscriptionNames);
 
     /**
      * Removes the subscriptions from the database for the given subscription names.
      * 
      */
     @RequestMapping(value = "/{subscriptionNames}", method = RequestMethod.DELETE)
-    public ResponseEntity<List<com.ericsson.ei.controller.model.SubscriptionResponse>> deleteSubscriptionById(
+    public ResponseEntity<List<String>> deleteSubscriptionById(
         @PathVariable
-        String subscriptionNames);
+        java.lang.String subscriptionNames);
 
 }

--- a/src/main/java/com/ericsson/ei/controller/model/Subscription.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Subscription.java
@@ -26,7 +26,9 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
     "repeat",
     "requirements",
     "subscriptionName",
-    "userName"
+    "userName",
+    "password",
+    "ldapUserName"
 })
 public class Subscription {
 
@@ -50,6 +52,10 @@ public class Subscription {
     private String subscriptionName;
     @JsonProperty("userName")
     private String userName;
+    @JsonProperty("password")
+    private String password;
+    @JsonProperty("ldapUserName")
+    private String ldapUserName;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -153,6 +159,26 @@ public class Subscription {
         this.userName = userName;
     }
 
+    @JsonProperty("password")
+    public String getPassword() {
+        return password;
+    }
+
+    @JsonProperty("password")
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @JsonProperty("ldapUserName")
+    public String getLdapUserName() {
+        return ldapUserName;
+    }
+
+    @JsonProperty("ldapUserName")
+    public void setLdapUserName(String ldapUserName) {
+        this.ldapUserName = ldapUserName;
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
@@ -170,7 +196,7 @@ public class Subscription {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(aggregationtype).append(created).append(notificationMeta).append(notificationType).append(restPostBodyMediaType).append(notificationMessageKeyValues).append(repeat).append(requirements).append(subscriptionName).append(userName).append(additionalProperties).toHashCode();
+        return new HashCodeBuilder().append(aggregationtype).append(created).append(notificationMeta).append(notificationType).append(restPostBodyMediaType).append(notificationMessageKeyValues).append(repeat).append(requirements).append(subscriptionName).append(userName).append(password).append(ldapUserName).append(additionalProperties).toHashCode();
     }
 
     @Override
@@ -182,7 +208,7 @@ public class Subscription {
             return false;
         }
         Subscription rhs = ((Subscription) other);
-        return new EqualsBuilder().append(aggregationtype, rhs.aggregationtype).append(created, rhs.created).append(notificationMeta, rhs.notificationMeta).append(notificationType, rhs.notificationType).append(restPostBodyMediaType, rhs.restPostBodyMediaType).append(notificationMessageKeyValues, rhs.notificationMessageKeyValues).append(repeat, rhs.repeat).append(requirements, rhs.requirements).append(subscriptionName, rhs.subscriptionName).append(userName, rhs.userName).append(additionalProperties, rhs.additionalProperties).isEquals();
+        return new EqualsBuilder().append(aggregationtype, rhs.aggregationtype).append(created, rhs.created).append(notificationMeta, rhs.notificationMeta).append(notificationType, rhs.notificationType).append(restPostBodyMediaType, rhs.restPostBodyMediaType).append(notificationMessageKeyValues, rhs.notificationMessageKeyValues).append(repeat, rhs.repeat).append(requirements, rhs.requirements).append(subscriptionName, rhs.subscriptionName).append(userName, rhs.userName).append(password, rhs.password).append(ldapUserName, rhs.ldapUserName).append(additionalProperties, rhs.additionalProperties).isEquals();
     }
 
 }

--- a/src/main/java/com/ericsson/ei/repository/ISubscriptionRepository.java
+++ b/src/main/java/com/ericsson/ei/repository/ISubscriptionRepository.java
@@ -18,18 +18,21 @@ package com.ericsson.ei.repository;
 
 import java.util.ArrayList;
 
+import org.bson.Document;
+import org.json.JSONException;
+
 import com.ericsson.ei.mongodbhandler.MongoDBHandler;
 
 public interface ISubscriptionRepository {
-    
+
     ArrayList<String> getSubscription(String name);
-    
-    boolean modifySubscription(String stringSubscription, String subscriptionName);
-    
+
+    Document modifySubscription(String stringSubscription, String subscriptionName) throws JSONException;
+
     boolean deleteSubscription(String name);
-    
+
     boolean addSubscription(String subscription);
-    
+
     MongoDBHandler getMongoDbHandler();
-    
+
 }

--- a/src/main/resources/public/raml/common-schema.raml
+++ b/src/main/resources/public/raml/common-schema.raml
@@ -61,6 +61,12 @@ subscription: |
           },
           "userName":{
              "type":"string"
+          },
+          "password":{
+             "type":"string"
+          },
+          "ldapUserName":{
+             "type":"string"
           }
        },
        "type":"object"
@@ -129,6 +135,12 @@ subscriptionList: |
              "type":"string"
           },
           "userName":{
+             "type":"string"
+          },
+          "password":{
+             "type":"string"
+          },
+          "ldapUserName":{
              "type":"string"
           }
        },

--- a/src/test/java/com/ericsson/ei/subscriptionhandler/test/SubscriptionHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/subscriptionhandler/test/SubscriptionHandlerTest.java
@@ -21,19 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.reflect.Whitebox.invokeMethod;
 
-import com.ericsson.ei.App;
-import com.ericsson.ei.controller.model.QueryResponse;
-import com.ericsson.ei.jmespath.JmesPathInterface;
-import com.ericsson.ei.mongodbhandler.MongoDBHandler;
-import com.ericsson.ei.subscriptionhandler.InformSubscription;
-import com.ericsson.ei.subscriptionhandler.RunSubscription;
-import com.ericsson.ei.subscriptionhandler.SendMail;
-import com.ericsson.ei.subscriptionhandler.SpringRestTemplate;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.mongodb.MongoClient;
-
 import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -61,6 +48,19 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
+import com.ericsson.ei.App;
+import com.ericsson.ei.controller.model.QueryResponse;
+import com.ericsson.ei.jmespath.JmesPathInterface;
+import com.ericsson.ei.mongodbhandler.MongoDBHandler;
+import com.ericsson.ei.subscriptionhandler.InformSubscription;
+import com.ericsson.ei.subscriptionhandler.RunSubscription;
+import com.ericsson.ei.subscriptionhandler.SendMail;
+import com.ericsson.ei.subscriptionhandler.SpringRestTemplate;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.mongodb.MongoClient;
 
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.tests.MongodForTestsFactory;
@@ -94,7 +94,7 @@ public class SubscriptionHandlerTest {
     private static MongodForTestsFactory testsFactory;
     private static MongoClient mongoClient = null;
     private static final String formKey = "Authorization";
-    private static final String formValue = "Basic XX0=";
+    private static final String formValue = "Basic dGVzdFVzZXJOYW1lOnRlc3RQYXNzd29yZA==";
     private ObjectMapper mapper = new ObjectMapper();
 
     @Autowired

--- a/src/test/resources/SubscriptionObjectForAuthorization.json
+++ b/src/test/resources/SubscriptionObjectForAuthorization.json
@@ -1,6 +1,9 @@
 {
         "subscriptionName": "Subscription_1",
-        "userName" : "DEF",
+        "ldapUserName" : "DEF",
+        "userName": "testUserName",
+        "password": "testPassword",
+        "authenticationType": "BASIC_AUTH",
         "repeat": false,
         "created": "data-time",
         "notificationType": "REST_POST",
@@ -10,10 +13,6 @@
           {
             "formkey" : "json",
             "formvalue" : "{parameter: [{ name: 'parameter', value : 'parameterValue' }]}"
-          },
-          {
-            "formkey" : "Authorization",
-            "formvalue" : "Basic XX0="
           }
         ],
 

--- a/src/test/resources/artifactRequirementSubscription.json
+++ b/src/test/resources/artifactRequirementSubscription.json
@@ -25,5 +25,5 @@
       }
     ],
     "subscriptionName": "artifactRequirementSubscription",
-    "userName": "ABC"
+    "ldapUserName": "ABC"
   }

--- a/src/test/resources/subscriptionForMapNotification.json
+++ b/src/test/resources/subscriptionForMapNotification.json
@@ -1,6 +1,6 @@
 {
   "subscriptionName": "Subscription_1",
-  "userName" : "DEF",
+  "ldapUserName" : "DEF",
   "repeat": false,
   "created": "data-time",
   "notificationType": "MAIL",


### PR DESCRIPTION
This is related to "Fix auth-behaviour" in EI-frontend and should be merged together.

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
- There was wierd behaviour regarding the saving of auth information (handling of
  username/password since it was used by ldap aswell as the subscription auth)
-If password was not updated from the user request, it would be removed.
- Auth information was sent out to the users in clear text.

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
- Broke the names for username appart to "ldapUserName" and "userName".
- Made sure mongoDB updates without removing unset fields.
- Made sure password is not sent out to the user by removing that field if it is set.
### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
