### PR TITLE
rewrite waitListWorker to be more fail safe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
             <exclusions>
-            	<exclusion>
-            		<groupId>com.vaadin.external.google</groupId>
-            		<artifactId>android-json</artifactId>
-            	</exclusion>
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20160810</version>
+            <version>20180130</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.github.wnameless/json-flattener -->

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.vaadin.external.google</groupId>
+            		<artifactId>android-json</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/trigger/SubscriptionTriggerSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/trigger/SubscriptionTriggerSteps.java
@@ -254,7 +254,7 @@ public class SubscriptionTriggerSteps extends FunctionalTestBase {
         JSONArray jsonArray = new JSONArray(restBodyData);
 
         for (int i = 0; i < jsonArray.length(); i++) {
-            String requestBody = jsonArray.getString(i);
+            String requestBody = jsonArray.get(i).toString();
             if (requestBody.contains("TC5")) {
                 tc5++;
             }

--- a/src/main/java/com/ericsson/ei/jmespath/JmesPathInterface.java
+++ b/src/main/java/com/ericsson/ei/jmespath/JmesPathInterface.java
@@ -16,13 +16,13 @@
  */
 package com.ericsson.ei.jmespath;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 import io.burt.jmespath.Expression;
 import io.burt.jmespath.JmesPath;
@@ -65,8 +65,8 @@ public class JmesPathInterface {
             result = expression.search(eventJson);
         } catch (Exception e) {
             String msg = "runRuleOnEvent failed for given arguments:\n";
-        	msg += "rule was: " + rule + "\n";
-        	msg += "event was: " + event + "\n";
+            msg += "rule was: " + rule + "\n";
+            msg += "event was: " + event + "\n";
             log.error(msg, e);
         }
 

--- a/src/main/java/com/ericsson/ei/jmespath/JmesPathInterface.java
+++ b/src/main/java/com/ericsson/ei/jmespath/JmesPathInterface.java
@@ -64,6 +64,9 @@ public class JmesPathInterface {
             JsonNode eventJson = objectMapper.readValue(event, JsonNode.class);
             result = expression.search(eventJson);
         } catch (Exception e) {
+        	log.info("runRuleOnEvent failed for given arguments:");
+        	log.info("rule was: " + rule);
+        	log.info("event was: " + event);
             log.info(e.getMessage(), e);
         }
 

--- a/src/main/java/com/ericsson/ei/jmespath/JmesPathInterface.java
+++ b/src/main/java/com/ericsson/ei/jmespath/JmesPathInterface.java
@@ -64,10 +64,10 @@ public class JmesPathInterface {
             JsonNode eventJson = objectMapper.readValue(event, JsonNode.class);
             result = expression.search(eventJson);
         } catch (Exception e) {
-        	log.info("runRuleOnEvent failed for given arguments:");
-        	log.info("rule was: " + rule);
-        	log.info("event was: " + event);
-            log.info(e.getMessage(), e);
+            String msg = "runRuleOnEvent failed for given arguments:\n";
+        	msg += "rule was: " + rule + "\n";
+        	msg += "event was: " + event + "\n";
+            log.error(msg, e);
         }
 
         return result;

--- a/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
+++ b/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
@@ -64,7 +64,7 @@ public class MergePrepare {
         } catch (JSONException e) {
             try {
                 JSONArray ruleJSONArray = new JSONArray(mergeRule);
-                return getValueFromRule(ruleJSONArray.getString(1));
+                return getValueFromRule(ruleJSONArray.get(1).toString());
             } catch (Exception ne) {
                 log.info(ne.getMessage(), ne);
             }
@@ -136,16 +136,9 @@ public class MergePrepare {
         try {
             JSONArray ruleJSONArray = new JSONArray(mergeRule);
             String firstRule = "";
-            String secondRule = "";
-            try {
-            	firstRule = ruleJSONArray.getString(0);
-            	secondRule = ruleJSONArray.getString(1);
-            } catch (Exception e) {
-            	log.error("Getting strings from RuleJSONArray failed: " + ruleJSONArray);
-            	log.error("First rule is: " + ruleJSONArray.get(0) + " of class " + ruleJSONArray.get(0).getClass());
-            	log.error("Second rule is: " + ruleJSONArray.get(1) + " of class " + ruleJSONArray.get(1).getClass());
-            	log.error(e.getMessage(), e);
-            }
+            String secondRule = "";            
+            firstRule = ruleJSONArray.get(0).toString();
+            secondRule = ruleJSONArray.get(1).toString();
             String firstPath = getMergePath(originObject, firstRule, false);
             String firstPathTrimmed = trimLastInPath(firstPath, ".");
 
@@ -471,7 +464,7 @@ public class MergePrepare {
             JSONObject originJSONObject = new JSONObject(originObject);
             Object valueForKey = null;
             for (int i = 0; i < mergePathIndex; i++) {
-                String key = mergePathArray.getString(i);
+                String key = mergePathArray.get(i).toString();
                 if (valueForKey == null && originJSONObject.has(key)) {
                     valueForKey = originJSONObject.get(key);
                 } else {

--- a/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
+++ b/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
@@ -441,6 +441,11 @@ public class MergePrepare {
                 }
             }
         } catch (Exception e) {
+        	log.error("addMissingLevels failed for arguments:");
+        	log.error("originObject was : " + originObject);
+        	log.error("objectTomerge was: " + objectToMerge);
+        	log.error("mergeRule was: " + mergeRule);
+        	log.error("mergePath was: " + mergePath);
             log.error(e.getMessage(), e);
         }
         return newObject.toString();

--- a/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
+++ b/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
@@ -142,8 +142,8 @@ public class MergePrepare {
             	secondRule = ruleJSONArray.getString(1);
             } catch (Exception e) {
             	log.error("Getting strings from RuleJSONArray failed: " + ruleJSONArray);
-            	log.error("First rule is: " + ruleJSONArray.get(0));
-            	log.error("Second rule is: " + ruleJSONArray.get(1));
+            	log.error("First rule is: " + ruleJSONArray.get(0) + " of class " + ruleJSONArray.get(0).getClass());
+            	log.error("Second rule is: " + ruleJSONArray.get(1) + " of class " + ruleJSONArray.get(1).getClass());
             	log.error(e.getMessage(), e);
             }
             String firstPath = getMergePath(originObject, firstRule, false);

--- a/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
+++ b/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
@@ -135,8 +135,17 @@ public class MergePrepare {
         log.debug(" originObject is : " + originObject);
         try {
             JSONArray ruleJSONArray = new JSONArray(mergeRule);
-            String firstRule = ruleJSONArray.getString(0);
-            String secondRule = ruleJSONArray.getString(1);
+            String firstRule = "";
+            String secondRule = "";
+            try {
+            	firstRule = ruleJSONArray.getString(0);
+            	secondRule = ruleJSONArray.getString(1);
+            } catch (Exception e) {
+            	log.error("Getting strings from RuleJSONArray failed: " + ruleJSONArray);
+            	log.error("First rule is: " + ruleJSONArray.get(0));
+            	log.error("Second rule is: " + ruleJSONArray.get(1));
+            	log.error(e.getMessage(), e);
+            }
             String firstPath = getMergePath(originObject, firstRule, false);
             String firstPathTrimmed = trimLastInPath(firstPath, ".");
 

--- a/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
+++ b/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
@@ -135,10 +135,8 @@ public class MergePrepare {
         log.debug(" originObject is : " + originObject);
         try {
             JSONArray ruleJSONArray = new JSONArray(mergeRule);
-            String firstRule = "";
-            String secondRule = "";            
-            firstRule = ruleJSONArray.get(0).toString();
-            secondRule = ruleJSONArray.get(1).toString();
+            String firstRule = ruleJSONArray.get(0).toString();
+            String secondRule = ruleJSONArray.get(1).toString();
             String firstPath = getMergePath(originObject, firstRule, false);
             String firstPathTrimmed = trimLastInPath(firstPath, ".");
 
@@ -443,12 +441,12 @@ public class MergePrepare {
                 }
             }
         } catch (Exception e) {
-        	log.error("addMissingLevels failed for arguments:");
-        	log.error("originObject was : " + originObject);
-        	log.error("objectTomerge was: " + objectToMerge);
-        	log.error("mergeRule was: " + mergeRule);
-        	log.error("mergePath was: " + mergePath);
-            log.error(e.getMessage(), e);
+        	String msg = "addMissingLevels failed for arguments:\n";
+        	msg += "originObject was : " + originObject + "\n";
+        	msg += "objectTomerge was: " + objectToMerge + "\n";
+        	msg += "mergeRule was: " + mergeRule + "\n";
+        	msg += "mergePath was: " + mergePath + "\n";
+            log.error(msg, e);
         }
         return newObject.toString();
     }

--- a/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
+++ b/src/main/java/com/ericsson/ei/jsonmerge/MergePrepare.java
@@ -16,13 +16,6 @@
 */
 package com.ericsson.ei.jsonmerge;
 
-import com.ericsson.ei.jmespath.JmesPathInterface;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.github.wnameless.json.flattener.JsonFlattener;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -35,6 +28,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import com.ericsson.ei.jmespath.JmesPathInterface;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.github.wnameless.json.flattener.JsonFlattener;
 
 import lombok.Setter;
 
@@ -441,11 +441,11 @@ public class MergePrepare {
                 }
             }
         } catch (Exception e) {
-        	String msg = "addMissingLevels failed for arguments:\n";
-        	msg += "originObject was : " + originObject + "\n";
-        	msg += "objectTomerge was: " + objectToMerge + "\n";
-        	msg += "mergeRule was: " + mergeRule + "\n";
-        	msg += "mergePath was: " + mergePath + "\n";
+            String msg = "addMissingLevels failed for arguments:\n";
+            msg += "originObject was : " + originObject + "\n";
+            msg += "objectTomerge was: " + objectToMerge + "\n";
+            msg += "mergeRule was: " + mergeRule + "\n";
+            msg += "mergePath was: " + mergePath + "\n";
             log.error(msg, e);
         }
         return newObject.toString();

--- a/src/main/java/com/ericsson/ei/waitlist/WaitListWorker.java
+++ b/src/main/java/com/ericsson/ei/waitlist/WaitListWorker.java
@@ -16,15 +16,9 @@
 */
 package com.ericsson.ei.waitlist;
 
-import com.ericsson.ei.handlers.EventToObjectMapHandler;
-import com.ericsson.ei.handlers.MatchIdRulesHandler;
-import com.ericsson.ei.jmespath.JmesPathInterface;
-import com.ericsson.ei.rmqhandler.RmqHandler;
-import com.ericsson.ei.rules.RulesHandler;
-import com.ericsson.ei.rules.RulesObject;
-import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collection;
+import java.util.List;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +29,14 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 import org.springframework.stereotype.Component;
 
-import java.util.Collection;
-import java.util.List;
+import com.ericsson.ei.handlers.EventToObjectMapHandler;
+import com.ericsson.ei.handlers.MatchIdRulesHandler;
+import com.ericsson.ei.jmespath.JmesPathInterface;
+import com.ericsson.ei.rmqhandler.RmqHandler;
+import com.ericsson.ei.rules.RulesHandler;
+import com.ericsson.ei.rules.RulesObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Component
 public class WaitListWorker {
@@ -66,33 +66,43 @@ public class WaitListWorker {
     }
 
     @Scheduled(initialDelayString = "${waitlist.initialDelayResend}", fixedRateString = "${waitlist.fixedRateResend}")
-    public void run() throws JSONException {
-        RulesObject rulesObject;
-        List<String> documents = waitListStorageHandler.getWaitList();
-        for (String document : documents) {
-            JSONObject eventObject = new JSONObject(document);
-            if (eventToObjectMapHandler.isEventInEventObjectMap(eventObject.getString("_id"))) {
-                waitListStorageHandler.dropDocumentFromWaitList(document);
-            } else {
-                String event = eventObject.getString("Event");
-                rulesObject = rulesHandler.getRulesForEvent(event);
-                String idRule = rulesObject.getIdentifyRules();
+    public void run(){
+    	RulesObject rulesObject;
+    	List<String> documents = waitListStorageHandler.getWaitList();
+    	for (String document : documents) {
+    		try {
+    			ObjectMapper objectMapper = new ObjectMapper();
+    			JsonNode eventJson = objectMapper.readTree(document);
+    			String id = eventJson.get("_id").asText();
+    			if (eventToObjectMapHandler.isEventInEventObjectMap(id)) {
+    				waitListStorageHandler.dropDocumentFromWaitList(document);
+    			} else {
+    				JsonNode event = eventJson.get("Event");
+    				String eventStr = event.asText();
+    				rulesObject = rulesHandler.getRulesForEvent(eventStr);
+    				String idRule = rulesObject.getIdentifyRules();
 
-                if (idRule != null && !idRule.isEmpty()) {
-                    JsonNode ids = jmesPathInterface.runRuleOnEvent(idRule, event);
-                    if (ids.isArray()) {
-                        LOGGER.debug("[EIFFEL EVENT RESENT] id:" + eventObject.getString("_id") + " time:"
-                                + eventObject.getString("Time"));
-                        for (final JsonNode idJsonObj : ids) {
-                            Collection<String> objects = matchIdRulesHandler.fetchObjectsById(rulesObject,
-                                    idJsonObj.textValue());
-                            if (!objects.isEmpty()) {
-                                rmqHandler.publishObjectToWaitlistQueue(event);
-                            }
-                        }
-                    }
-                }
-            }
+    				if (idRule != null && !idRule.isEmpty()) {
+    					JsonNode ids = jmesPathInterface.runRuleOnEvent(idRule, eventStr);
+    					if (ids.isArray()) {
+    						JsonNode idNode = eventJson.get("_id");
+    						JsonNode timeNode = eventJson.get("Time");
+    						LOGGER.debug("[EIFFEL EVENT RESENT] id:" + idNode.textValue() + " time:"
+    								+ timeNode);
+    						for (final JsonNode idJsonObj : ids) {
+    							Collection<String> objects = matchIdRulesHandler.fetchObjectsById(rulesObject,
+    									idJsonObj.textValue());
+    							if (!objects.isEmpty()) {
+    								rmqHandler.publishObjectToWaitlistQueue(eventStr);
+    							}
+    						}
+    					}
+    				}
+    			}
+    		} catch (Exception e) {
+    			LOGGER.error("Exception occured while trying to resend event: " + document);
+    			e.printStackTrace();
+    		}
         }
     }
 }

--- a/src/test/java/com/ericsson/ei/rules/test/TestRulesRestAPI.java
+++ b/src/test/java/com/ericsson/ei/rules/test/TestRulesRestAPI.java
@@ -105,7 +105,8 @@ public class TestRulesRestAPI {
 
         assertEquals(HttpStatus.OK.value(), result.getResponse().getStatus());
         assertEquals("e90daae3-bf3f-4b0a-b899-67834fd5ebd0", obj.getString("id"));
-        assertEquals("1484061386383", obj.getString("time"));
+        long timeV = 1484061386383L;
+        assertEquals(timeV, obj.getLong("time"));
 
     }
 


### PR DESCRIPTION

### Applicable Issues
Resending events in waitlist was broken when loaded in Tomcat with other version of JSON library

### Description of the Change
Changed to jackson json library which will return objects or empty strings and less requirement to have keys in a Json object. Exceptions are no longer thrown but an error message is logged in order to allow processing of coming events in the waitlist to be sent.

### Alternate Designs
None

### Benefits
WaitlistWork less dependent of keys existing or not ad their type.

### Possible Drawbacks
None

### Sign-off
Vasile Baluta, vasile.baluta@ericsson.com