### PR TITLE
Fix versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,13 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.7</version>
         </dependency>
-
+        
+	    <dependency>
+		      <groupId>org.apache.maven</groupId>
+		      <artifactId>maven-model</artifactId>
+		      <version>3.3.9</version>
+	    </dependency>
+	    
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.7</version>
         </dependency>
-	    
+
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,12 +182,6 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.7</version>
         </dependency>
-        
-	    <dependency>
-		      <groupId>org.apache.maven</groupId>
-		      <artifactId>maven-model</artifactId>
-		      <version>3.3.9</version>
-	    </dependency>
 	    
         <dependency>
             <groupId>io.springfox</groupId>
@@ -280,6 +274,22 @@
 
     </dependencies>
     <build>
+        <resources>
+	        <resource>
+	            <directory>src/main/resources</directory>
+	            <filtering>true</filtering>
+	            <includes>
+	                <include>**/default-application.properties</include>
+	            </includes>
+	        </resource>
+	        <resource>
+	            <directory>src/main/resources</directory>
+	            <filtering>false</filtering>
+	            <excludes>
+	                <exclude>**/default-application.properties</exclude>
+	            </excludes>
+	        </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
+++ b/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
@@ -25,9 +25,6 @@ import com.ericsson.ei.subscriptionhandler.SubscriptionHandler;
 import com.ericsson.ei.waitlist.WaitListStorageHandler;
 import lombok.Getter;
 
-import org.apache.maven.model.Model;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -36,6 +33,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 
 import javax.annotation.PostConstruct;
 
@@ -112,16 +110,11 @@ public class ParseInstanceInfoEI {
     private ERQueryService erUrl;
 
     @PostConstruct
-    public void init() throws IOException, XmlPullParserException {
-        getDataFromPom();
-    }
-
-    private void getDataFromPom() throws FileNotFoundException, IOException, XmlPullParserException {
-        MavenXpp3Reader reader = new MavenXpp3Reader();
-        Model model;
-        model = reader.read(new FileReader("pom.xml"));
-        applicationName = model.getArtifactId();
-        version = model.getVersion();
+    public void init() throws IOException {
+        Properties properties = new Properties();
+        properties.load(ParseInstanceInfoEI.class.getResourceAsStream("/default-application.properties"));
+        version = properties.getProperty("version");
+        applicationName = properties.getProperty("artifactId");
     }
 
     @Component

--- a/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
+++ b/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
@@ -44,12 +44,8 @@ import javax.annotation.PostConstruct;
 @Component
 public class ParseInstanceInfoEI {
     @Getter
-    @Value("${build.version.name::#{null}}")
-    private String EnterpriseVersionName;
-
-    @Getter
     @Value("${build.version:#{null}}")
-    private String EnterpriseVersion;
+    private String applicationPropertiesVersion;
 
     @Getter
     private String version;

--- a/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
+++ b/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
@@ -24,11 +24,20 @@ import com.ericsson.ei.subscriptionhandler.SendMail;
 import com.ericsson.ei.subscriptionhandler.SubscriptionHandler;
 import com.ericsson.ei.waitlist.WaitListStorageHandler;
 import lombok.Getter;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.List;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Parsing all classes which contains value annotation in eiffel-intelligence plugin.
@@ -36,14 +45,19 @@ import java.util.List;
  */
 @Component
 public class ParseInstanceInfoEI {
+    @Getter
+    @Value("${build.version.name::#{null}}")
+    private String EnterpriseVersionName;
 
     @Getter
-    @Value("${spring.application.name}")
-    private String applicationName;
+    @Value("${build.version:#{null}}")
+    private String EnterpriseVersion;
 
     @Getter
-    @Value("${build.version}")
     private String version;
+
+    @Getter
+    private String applicationName;
 
     @Getter
     @Value("${rules.path}")
@@ -97,7 +111,17 @@ public class ParseInstanceInfoEI {
     @Autowired
     private ERQueryService erUrl;
 
-    public ParseInstanceInfoEI(){
+    @PostConstruct
+    public void init() throws IOException, XmlPullParserException {
+        getDataFromPom();
+    }
+
+    private void getDataFromPom() throws FileNotFoundException, IOException, XmlPullParserException {
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model;
+        model = reader.read(new FileReader("pom.xml"));
+        applicationName = model.getArtifactId();
+        version = model.getVersion();
     }
 
     @Component

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=eiffel-intelligence
 #${project.artifactId}
 
-# Set extra optional version flag, example: Enterprise Version 
-build.version.name=
+# An extra optional version tag, version will be added after github release version 
+# Example if build.version=1.2.3-internal becomes Version 0.0.18 (1.2.3-internal)
 build.version=
 
 # port where Eiffel Intelligence will run

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,9 @@
 spring.application.name=eiffel-intelligence
 #${project.artifactId}
 
-build.version=@project.version@
+# Set extra optional version flag, example: Enterprise Version 
+build.version.name=
+build.version=
 
 # port where Eiffel Intelligence will run
 server.port: 8090

--- a/src/main/resources/default-application.properties
+++ b/src/main/resources/default-application.properties
@@ -1,0 +1,2 @@
+artifactId=@project.artifactId@
+version=@project.version@

--- a/src/test/java/com/ericsson/ei/rules/test/TestRulesRestAPI.java
+++ b/src/test/java/com/ericsson/ei/rules/test/TestRulesRestAPI.java
@@ -142,8 +142,13 @@ public class TestRulesRestAPI {
         }
     }
 
+    /**
+     * TestRulePageEnabled should always be false when pushed to Github.
+     *
+     * @throws Exception
+     */
     @Test
-    public void testGetTestRulePageEnabledAPI_setPropertyDefult() throws Exception {
+    public void testGetTestRulePageEnabledAPI_ensurePropertyFalse() throws Exception {
         String responseBody = new JSONObject().put("status", false).toString();
         mockMvc.perform(MockMvcRequestBuilders.get("/rules/rule-check/testRulePageEnabled")
                 .accept(MediaType.APPLICATION_JSON_VALUE)).andExpect(status().isOk())


### PR DESCRIPTION
Application information such as application name and version is stored in the default-application.properties instead of the application.properties that may be over written by users. This enables us to make use of those values in the front end and display the correct versions.

There is also new fields in the application.properties, build.version.name and =build.version is seperated from the version displayed from the pom, the users may add their own version name if verison is set, if version is set without name then it will be displayed as Enterprise Version in EI front end.
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
