### PR TITLE
Add travis deploy on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ script:
 #
 # It is also important that the first test to be run is a Spring Boot Test since spring boot also downloads
 # another version of embedded mongo db so all Spring Boot tests will end up in a race condition also
-  -  mvn -DsomeModule.test.includes="**/QueryServiceTest.java" test
+  #-  mvn -DsomeModule.test.includes="**/QueryServiceTest.java" test
   #-  mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test
+
   - rm -rf docs
   - mvn site
   - mvn clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ script:
 #
 # It is also important that the first test to be run is a Spring Boot Test since spring boot also downloads
 # another version of embedded mongo db so all Spring Boot tests will end up in a race condition also
-  #-  mvn -DsomeModule.test.includes="**/QueryServiceTest.java" test
-  #-  mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test
+  -  mvn -DsomeModule.test.includes="**/QueryServiceTest.java" test
+  -  mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test
 
+before_deploy:
   - rm -rf docs
   - mvn site
   - mvn clean
@@ -30,4 +31,4 @@ deploy:
   github-token: $GITHUB_TOKEN
   local_dir: docs/
   on:
-    branch: travis-test
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,30 @@ language: java
 
 jdk:
   - oraclejdk8
-  
+
 before_install:
   - uname -a
   - chmod +x pom.xml
-  
+
 script:
-# since we run parallel tests using embedded mongodb in fresh environment all tests run first in parallel 
+# since we run parallel tests using embedded mongodb in fresh environment all tests run first in parallel
 # will try to download the embedded mongo to this travis instance but the late ones will fail to write.
 # We will therefore run one test using mongodb first that will download the mongo instance and
 # then the rest of the test that will no longer need to download the embedded mongo since it will exist.
 #
-# It is also importan that the first test to be run is a Spring Boot Test since spring boot also downloads
+# It is also important that the first test to be run is a Spring Boot Test since spring boot also downloads
 # another version of embedded mongo db so all Spring Boot tests will end up in a race condition also
   -  mvn -DsomeModule.test.includes="**/QueryServiceTest.java" test
-  -  mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test 
+  -  mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test
+  - rm -rf docs
+  - mvn site
+  - mvn clean
+
+deploy:
+  skip_cleanup: true
+  provider: pages
+  github-token: $GITHUB_TOKEN
+  local_dir: docs/
+  on:
+    branch: travis-test  # temp for test
+  keep-history: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
 # It is also important that the first test to be run is a Spring Boot Test since spring boot also downloads
 # another version of embedded mongo db so all Spring Boot tests will end up in a race condition also
   -  mvn -DsomeModule.test.includes="**/QueryServiceTest.java" test
-  -  mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test
+  #-  mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test
   - rm -rf docs
   - mvn site
   - mvn clean
@@ -29,5 +29,4 @@ deploy:
   github-token: $GITHUB_TOKEN
   local_dir: docs/
   on:
-    branch: travis-test  # temp for test
-  keep-history: true
+    branch: travis-test


### PR DESCRIPTION
### Applicable Issues
We want travis to handle deployment to github pages instead of having to use mvn commands locally before pushing to repo.

### Description of the Change
A deploy step is added to the travis file. Deployment is only done on master branch. The pages are published to the brnch gh-pages by default. Update repo settings to use gh-pages branch instead of master branch docs/ directory. $GITHUB_TOKEN used in deployment job is set in travis ci settings.

### Benefits
Developer does not have to manually run mvn site and mvn clean to update documentation before commit to repo. Note: whenever documentation is updated in a change it is HIGHLY recommended to test locally!


### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
