### PR TITLE
Removed hard coded log levels

### DIFF
--- a/src/main/java/com/ericsson/ei/App.java
+++ b/src/main/java/com/ericsson/ei/App.java
@@ -50,10 +50,6 @@ public class App extends SpringBootServletInitializer {
             System.setProperty("logging.level.root", args[0]);
             System.setProperty("logging.level.org.springframework.web", args[0]);
             System.setProperty("logging.level.com.ericsson.ei", args[0]);
-        } else {
-            System.setProperty("logging.level.root", "OFF");
-            System.setProperty("logging.level.org.springframework.web", "OFF");
-            System.setProperty("logging.level.com.ericsson.ei", "OFF");
         }
 
         ConfigurableBeanFactory beanFactory = new DefaultListableBeanFactory();


### PR DESCRIPTION
### Applicable Issues
It was previously hardcoded to turn off logging if no specific arguments were added when starting up EI backend. When using mvn spring-boot:run the logging was always turned off and overriding the application.properties .

### Description of the Change
When starting up EI backend it is still possible to specify log level arguments when using the war file.

"java -jar target/eiffel-intelligence-X.X.X.war DEBUG"
If no log levels are passed in as arguments then the application.properties values are used.

### Benefits
Easier to startup EI backend using mvn spring-boot:run

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
