### PR TITLE
fix ttl test failed in windows, split test functions

### DIFF
--- a/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
@@ -175,33 +175,22 @@ public class TestTTLSteps extends FunctionalTestBase {
     @When("^Missed notification is created$")
     public void a_missed_notification_is_created() throws Throwable {
         // verifying that missed notification is created and present in db
+        int expectedSize = 1;
         String condition = "{\"subscriptionName\" : \"" + SUBSCRIPTION_NAME_3 + "\"}";
-        long maxTime = System.currentTimeMillis() + MAX_WAIT_TIME;
-        List<String> notificationExit = null;
+
         LOGGER.debug("Checking presence of missnotification in db");
-        while (System.currentTimeMillis() < maxTime) {
-            notificationExit = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
-            if (!notificationExit.isEmpty()) {
-                break;
-            }
-        }
-        assertEquals(1, notificationExit.size());
+        int notificationExistSize = getNotificationForExpectedSize(expectedSize, condition);
+        assertEquals(expectedSize, notificationExistSize);
     }
 
     @Then("^Notification document should be deleted from the database$")
     public void the_Notification_document_should_be_deleted_from_the_database() throws Throwable {
-        long maxTime = System.currentTimeMillis() + MAX_WAIT_TIME;
-        List<String> notificationExit = null;
+        int expectedSize = 0;
         String condition = "{\"subscriptionName\" : \"" + SUBSCRIPTION_NAME_3 + "\"}";
         LOGGER.debug("Checking deletion of notification document in db");
-        while (System.currentTimeMillis() < maxTime) {
-            notificationExit = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
 
-            if (notificationExit.isEmpty()) {
-                break;
-            }
-        }
-        assertEquals(0, notificationExit.size());
+        int notificationExistSize = getNotificationForExpectedSize(expectedSize, condition);
+        assertEquals(expectedSize, notificationExistSize);
     }
 
     @Then("^Aggregated Object document should be deleted from the database$")
@@ -234,5 +223,19 @@ public class TestTTLSteps extends FunctionalTestBase {
         List<String> eventNames = new ArrayList<>();
         eventNames.add("event_EiffelArtifactCreatedEvent_3");
         return eventNames;
+    }
+
+    private int getNotificationForExpectedSize(int expectedSize, String condition) {
+        long maxTime = System.currentTimeMillis() + MAX_WAIT_TIME;
+        List<String> notificationExist = null;
+
+        while (System.currentTimeMillis() < maxTime) {
+            notificationExist = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
+
+            if (notificationExist.size() == expectedSize) {
+                return notificationExist.size();
+            }
+        }
+        return notificationExist.size();
     }
 }

--- a/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
@@ -42,196 +42,197 @@ import cucumber.api.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = { "notification.ttl.value:1", "aggregated.collection.ttlValue:1",
-		"notification.failAttempt:1" })
+        "notification.failAttempt:1" })
 @ContextConfiguration(initializers = TestContextInitializer.class)
 public class TestTTLSteps extends FunctionalTestBase {
-	private static final Logger LOGGER = LoggerFactory.getLogger(TestTTLSteps.class);
-	private static final String BASE_URL = "localhost";
-	private static final String ENDPOINT = "/missed_notification";
-	private static final String SUBSCRIPTION_NAME = "Subscription_1";
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestTTLSteps.class);
+    private static final String BASE_URL = "localhost";
+    private static final String ENDPOINT = "/missed_notification";
+    private static final String SUBSCRIPTION_NAME = "Subscription_1";
 
-	private static final String SUBSCRIPTION_NAME_3 = "Subscription_Test_3";
+    private static final String SUBSCRIPTION_NAME_3 = "Subscription_Test_3";
 
-	@LocalServerPort
-	private int applicationPort;
-	private String hostName = getHostName();
-	private HttpRequest httpRequest;
-	private static final String SUBSCRIPTION_FILE_PATH = "src/functionaltests/resources/SubscriptionObject.json";
+    @LocalServerPort
+    private int applicationPort;
+    private String hostName = getHostName();
+    private HttpRequest httpRequest;
 
-	private static final String AGGREGATED_OBJECT_FILE_PATH = "src/test/resources/AggregatedObject.json";
+    private static final String SUBSCRIPTION_FILE_PATH = "src/functionaltests/resources/SubscriptionObject.json";
+    private static final String AGGREGATED_OBJECT_FILE_PATH = "src/test/resources/AggregatedObject.json";
+    private static final String SUBSCRIPTION_FILE_PATH_CREATION = "src/functionaltests/resources/subscription_single_ttlTest.json";
+    private static final String EIFFEL_EVENTS_JSON_PATH = "src/functionaltests/resources/eiffel_events_for_test.json";
 
-	private static final String SUBSCRIPTION_FILE_PATH_CREATION = "src/functionaltests/resources/subscription_single_ttlTest.json";
+    private static final long MAX_WAIT_TIME = 65000;
 
-	private static final String EIFFEL_EVENTS_JSON_PATH = "src/functionaltests/resources/eiffel_events_for_test.json";
+    private static JsonNode subscriptionObject;
 
-	private static JsonNode subscriptionObject;
+    private MockServerClient mockServerClient;
+    private ClientAndServer clientAndServer;
 
-	private MockServerClient mockServerClient;
-	private ClientAndServer clientAndServer;
+    @Value("${missedNotificationDataBaseName}")
+    private String missedNotificationDatabase;
 
-	@Value("${missedNotificationDataBaseName}")
-	private String missedNotificationDatabase;
+    @Value("${missedNotificationCollectionName}")
+    private String missedNotificationCollection;
 
-	@Value("${missedNotificationCollectionName}")
-	private String missedNotificationCollection;
+    @Value("${spring.data.mongodb.database}")
+    private String dataBase;
 
-	@Value("${spring.data.mongodb.database}")
-	private String dataBase;
+    @Value("${aggregated.collection.name}")
+    private String collection;
 
-	@Value("${aggregated.collection.name}")
-	private String collection;
+    @Autowired
+    private MongoDBHandler mongoDBHandler;
 
-	@Autowired
-	private MongoDBHandler mongoDBHandler;
+    @Autowired
+    private InformSubscription informSubscription;
 
-	@Autowired
-	private InformSubscription informSubscription;
+    @Before("@TestNotificationRetries")
+    public void beforeScenario() {
+        setUpMockServer();
+    }
 
-	@Before("@TestNotificationRetries")
-	public void beforeScenario() {
-		setUpMockServer();
-	}
+    @After("@TestNotificationRetries")
+    public void afterScenario() throws IOException {
+        LOGGER.debug("Shutting down mock servers.");
+        mockServerClient.close();
+        clientAndServer.stop();
+    }
 
-	@After("@TestNotificationRetries")
-	public void afterScenario() throws IOException {
-		LOGGER.debug("Shutting down mock servers.");
-		mockServerClient.close();
-		clientAndServer.stop();
-	}
+    @Given("^Subscription is created$")
+    public void create_subscription_object() throws IOException, JSONException {
 
+        LOGGER.debug("Starting scenario @TestNotificationRetries.");
+        mongoDBHandler.dropCollection(missedNotificationDatabase, missedNotificationCollection);
 
-	@Given("^Subscription is created$")
-	public void create_subscription_object() throws IOException, JSONException {
+        String subscriptionStr = FileUtils.readFileToString(new File(SUBSCRIPTION_FILE_PATH), "utf-8");
 
-		LOGGER.debug("Starting scenario @TestNotificationRetries.");
-		mongoDBHandler.dropCollection(missedNotificationDatabase, missedNotificationCollection);
+        // replace with port of running mock server
+        subscriptionStr = subscriptionStr.replaceAll("\\{port\\}", String.valueOf(clientAndServer.getPort()));
 
-		String subscriptionStr = FileUtils.readFileToString(new File(SUBSCRIPTION_FILE_PATH), "utf-8");
+        subscriptionObject = new ObjectMapper().readTree(subscriptionStr);
+        assertEquals(false, subscriptionObject.get("notificationMeta").toString().contains("{port}"));
+    }
 
-		// replace with port of running mock server
-		subscriptionStr = subscriptionStr.replaceAll("\\{port\\}", String.valueOf(clientAndServer.getPort()));
+    @When("^I want to inform subscriber$")
+    public void inform_subscriber() throws IOException {
+        JsonNode aggregatedObject = eventManager.getJSONFromFile(AGGREGATED_OBJECT_FILE_PATH);
+        informSubscription.informSubscriber(aggregatedObject.toString(), subscriptionObject);
+    }
 
-		subscriptionObject = new ObjectMapper().readTree(subscriptionStr);
-		assertEquals(false, subscriptionObject.get("notificationMeta").toString().contains("{port}"));
-	}
+    @Then("^Verify that request has been retried")
+    public void verify_request_has_been_made() throws JSONException {
 
-	@When("^I want to inform subscriber$")
-	public void inform_subscriber() throws IOException {
-		JsonNode aggregatedObject = eventManager.getJSONFromFile(AGGREGATED_OBJECT_FILE_PATH);
-		informSubscription.informSubscriber(aggregatedObject.toString(), subscriptionObject);
-	}
+        String retrievedRequests = mockServerClient.retrieveRecordedRequests(request().withPath(ENDPOINT), Format.JSON);
+        JSONArray requests = new JSONArray(retrievedRequests);
 
-	@Then("^Verify that request has been retried")
-	public void verify_request_has_been_made() throws JSONException {
+        // received requests include number of retries
+        assertEquals(2, requests.length());
+    }
 
-		String retrievedRequests = mockServerClient.retrieveRecordedRequests(request().withPath(ENDPOINT), Format.JSON);
-		JSONArray requests = new JSONArray(retrievedRequests);
+    @Then("^Check missed notification is in database$")
+    public void check_missed_notification_is_in_database() {
+        String condition = "{\"subscriptionName\" : \"" + SUBSCRIPTION_NAME + "\"}";
+        List<String> result = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
 
-		// received requests include number of retries
-		assertEquals(2, requests.length());
-	}
+        assertEquals(1, result.size());
+        assertEquals("Could not find a missed notification matching the condition: " + condition,
+                "\"" + SUBSCRIPTION_NAME + "\"", dbManager.getValueFromQuery(result, "subscriptionName", 0));
+    }
 
-	@Then("^Check missed notification is in database$")
-	public void check_missed_notification_is_in_database() {
-		String condition = "{\"subscriptionName\" : \"" + SUBSCRIPTION_NAME + "\"}";
-		List<String> result = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
+    @Given("^A subscription is created using \"([^\"]*)\" with non-working notification meta$")
+    public void a_subscription_is_created_at_the_end_point_with_non_existent_notification_meta(String endPoint)
+            throws Throwable {
+        String readFileToString = FileUtils.readFileToString(new File(SUBSCRIPTION_FILE_PATH_CREATION), "UTF-8");
+        JSONArray jsonArr = new JSONArray(readFileToString);
+        httpRequest = new HttpRequest(HttpMethod.POST);
+        httpRequest.setHost(hostName).setPort(applicationPort).setEndpoint(endPoint)
+                .addHeader("content-type", "application/json").addHeader("Accept", "application/json")
+                .setBody(jsonArr.toString());
+        httpRequest.performRequest();
+    }
 
-		assertEquals(1, result.size());
-		assertEquals("Could not find a missed notification matching the condition: " + condition,
-				"\"" + SUBSCRIPTION_NAME + "\"", dbManager.getValueFromQuery(result, "subscriptionName", 0));
-	}
+    @Given("^I send an Eiffel event$")
+    public void eiffel_events_are_sent() throws Throwable {
+        LOGGER.debug("Sending an Eiffel event");
+        List<String> eventNamesToSend = getEventNamesToSend();
+        eventManager.sendEiffelEvents(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend);
+        List<String> missingEventIds = dbManager
+                .verifyEventsInDB(eventManager.getEventsIdList(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend));
+        assertEquals("The following events are missing in mongoDB: " + missingEventIds.toString(), 0,
+                missingEventIds.size());
+        LOGGER.debug("Eiffel event is sent");
+    }
 
-	@Given("^A subscription is created  at the end point \"([^\"]*)\" with non-existent notification meta$")
-	public void a_subscription_is_created_at_the_end_point_with_non_existent_notification_meta(String endPoint)
-			throws Throwable {
-		String readFileToString = FileUtils.readFileToString(new File(SUBSCRIPTION_FILE_PATH_CREATION), "UTF-8");
-		JSONArray jsonArr = new JSONArray(readFileToString);
-		httpRequest = new HttpRequest(HttpMethod.POST);
-		httpRequest.setHost(hostName).setPort(applicationPort).setEndpoint(endPoint)
-				.addHeader("content-type", "application/json").addHeader("Accept", "application/json")
-				.setBody(jsonArr.toString());
-		httpRequest.performRequest();
-	}
+    @When("^Aggregated object is created$")
+    public void aggregated_object_is_created() throws Throwable {
+        // verify that aggregated object is created and present in db
+        LOGGER.debug("Checking presence of aggregated Object");
+        List<String> allObjects = mongoDBHandler.getAllDocuments(dataBase, collection);
+        assertEquals(1, allObjects.size());
+    }
 
-	@Given("^I send an Eiffel event and consequently aggregated object and thereafter missed notification is created$")
-	public void i_send_an_Eiffel_event_and_consequently_aggregated_object_and_thereafter_missed_notification_is_created()
-			throws Throwable {
-		LOGGER.debug("Sending an Eiffel event");
-		List<String> eventNamesToSend = getEventNamesToSend();
-		eventManager.sendEiffelEvents(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend);
-		List<String> missingEventIds = dbManager
-				.verifyEventsInDB(eventManager.getEventsIdList(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend));
-		assertEquals("The following events are missing in mongoDB: " + missingEventIds.toString(), 0,
-				missingEventIds.size());
-		LOGGER.debug("Eiffel event is sent");
+    @When("^Missed notification is created$")
+    public void a_missed_notification_is_created() throws Throwable {
+        // verifying that missed notification is created and present in db
+        String condition = "{\"subscriptionName\" : \"" + SUBSCRIPTION_NAME_3 + "\"}";
+        long maxTime = System.currentTimeMillis() + MAX_WAIT_TIME;
+        List<String> notificationExit = null;
+        LOGGER.debug("Checking presence of missnotification in db");
+        while (System.currentTimeMillis() < maxTime) {
+            notificationExit = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
+            if (!notificationExit.isEmpty()) {
+                break;
+            }
+        }
+        assertEquals(1, notificationExit.size());
+    }
 
-		// verify that aggregated object is created and present in db
-		LOGGER.debug("Checking presence of aggregated Object");
-		List<String> allObjects = mongoDBHandler.getAllDocuments(dataBase, collection);
-		assertEquals(1, allObjects.size());
+    @Then("^Notification document should be deleted from the database$")
+    public void the_Notification_document_should_be_deleted_from_the_database() throws Throwable {
+        long maxTime = System.currentTimeMillis() + MAX_WAIT_TIME;
+        List<String> notificationExit = null;
+        String condition = "{\"subscriptionName\" : \"" + SUBSCRIPTION_NAME_3 + "\"}";
+        LOGGER.debug("Checking deletion of notification document in db");
+        while (System.currentTimeMillis() < maxTime) {
+            notificationExit = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
 
-		// verifying that missed notification is created and present in db
-		String condition = "{\"subscriptionName\" : \"" + SUBSCRIPTION_NAME_3 + "\"}";
-		long maxTime = System.currentTimeMillis() + 3000;
-		List<String> notificationExit = null;
-		LOGGER.debug("Checking presence of missnotification in db");
-		while (System.currentTimeMillis() < maxTime) {
-			notificationExit = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
-			if (!notificationExit.isEmpty()) {
-				break;
-			}
-		}
-		assertEquals(1, notificationExit.size());
-	}
+            if (notificationExit.isEmpty()) {
+                break;
+            }
+        }
+        assertEquals(0, notificationExit.size());
+    }
 
+    @Then("^Aggregated Object document should be deleted from the database$")
+    public void the_Aggregated_Object_document_should_be_deleted_from_the_database() throws Throwable {
+        LOGGER.debug("Checking delition of aggregated object in db");
+        List<String> allObjects = null;
+        allObjects = mongoDBHandler.getAllDocuments(dataBase, collection);
+        assertEquals("Database is not empty.", true, allObjects.isEmpty());
+    }
 
-	@Then("^the Notification document should be deleted from the database according to ttl value$")
-	public void the_Notification_document_should_be_deleted_from_the_database_according_to_ttl_value()
-			throws Throwable {
-		long maxTime = System.currentTimeMillis() + 60000;
-		List<String> notificationExit = null;
-		String condition = "{\"subscriptionName\" : \"" + SUBSCRIPTION_NAME_3 + "\"}";
-		LOGGER.debug("Checking deletion of notification document in db");
-		while (System.currentTimeMillis() < maxTime) {
-			notificationExit = mongoDBHandler.find(missedNotificationDatabase, missedNotificationCollection, condition);
+    /**
+     * Setting up mock server to receive calls on one endpoint and respond with
+     * 500 to trigger retries of POST request
+     */
+    private void setUpMockServer() {
+        int port = SocketUtils.findAvailableTcpPort();
+        clientAndServer = ClientAndServer.startClientAndServer(port);
+        LOGGER.debug("Setting up mockServerClient with port " + port);
+        mockServerClient = new MockServerClient(BASE_URL, port);
 
-			if (notificationExit.isEmpty()) {
-				break;
-			}
-		}
-		assertEquals(0, notificationExit.size());
-	}
+        // set up expectations on mock server to get calls on this endpoint
+        mockServerClient.when(request().withMethod("POST").withPath(ENDPOINT))
+                .respond(HttpResponse.response().withStatusCode(500));
+    }
 
-	@Then("^the Aggregated Object document should be deleted from the database according to ttl value$")
-	public void the_Aggregated_Object_document_should_be_deleted_from_the_database_according_to_ttl_value()
-			throws Throwable {
-		LOGGER.debug("Checking delition of aggregated object in db");
-		List<String> allObjects = null;
-		allObjects = mongoDBHandler.getAllDocuments(dataBase, collection);
-		assertEquals("Database is not empty.", true, allObjects.isEmpty());
-	}
-
-	/**
-	 * Setting up mock server to receive calls on one endpoint and respond with 500
-	 * to trigger retries of POST request
-	 */
-	private void setUpMockServer() {
-		int port = SocketUtils.findAvailableTcpPort();
-		clientAndServer = ClientAndServer.startClientAndServer(port);
-		LOGGER.debug("Setting up mockServerClient with port " + port);
-		mockServerClient = new MockServerClient(BASE_URL, port);
-
-		// set up expectations on mock server to get calls on this endpoint
-		mockServerClient.when(request().withMethod("POST").withPath(ENDPOINT))
-				.respond(HttpResponse.response().withStatusCode(500));
-	}
-
-	/**
-	 * Events used in the aggregation.
-	 */
-	protected List<String> getEventNamesToSend() {
-		List<String> eventNames = new ArrayList<>();
-		eventNames.add("event_EiffelArtifactCreatedEvent_3");
-		return eventNames;
-	}
+    /**
+     * Events used in the aggregation.
+     */
+    protected List<String> getEventNamesToSend() {
+        List<String> eventNames = new ArrayList<>();
+        eventNames.add("event_EiffelArtifactCreatedEvent_3");
+        return eventNames;
+    }
 }

--- a/src/functionaltests/resources/features/ttl.feature
+++ b/src/functionaltests/resources/features/ttl.feature
@@ -12,8 +12,9 @@ Feature: TestTTL
     
   @TestTTLforAutomaticSubscriptionTrigger
   Scenario: Test time to live for missed notification and aggregated object with an automatic subscription trigger flow setup
-    Given A subscription is created  at the end point "/subscriptions" with non-existent notification meta 
-    And I send an Eiffel event and consequently aggregated object and thereafter missed notification is created
-    Then the Notification document should be deleted from the database according to ttl value
-    And the Aggregated Object document should be deleted from the database according to ttl value 
-
+    Given A subscription is created using "/subscriptions" with non-working notification meta 
+    And I send an Eiffel event
+    When Aggregated object is created
+    And Missed notification is created
+    Then Notification document should be deleted from the database
+    And Aggregated Object document should be deleted from the database


### PR DESCRIPTION
Fixed Test TTL for Automatic Subscription Trigger to work in  windows.

Since it was hard to follow one of the test steps as it did three different things I split one step to 3 steps.

Run test using command: `mvn -Dtest=TestTTLRunner test -Dcucumber.options="--tags @TestTTLforAutomaticSubscriptionTrigger"`

Changed all taps to 4 spaces.

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
