### PR TITLE
Query no content response code is now 204

### DIFF
--- a/src/functionaltests/java/com/ericsson/ei/query/QueryAggregatedObjectsTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/query/QueryAggregatedObjectsTestSteps.java
@@ -132,7 +132,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
         String actualTestCaseFinishedEventId = responseEntityFormattedJsonNode.get("aggregatedObject")
                 .get("testCaseExecutions").get(0).get("testCaseFinishedEventId").asText();
 
-        assertEquals(HttpStatus.OK.toString(), Integer.toString(response.getStatusCodeValue()));
+        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals(
                 "Failed to compare actual Aggregated Object TestCaseFinishedEventId:\n" + actualTestCaseFinishedEventId
                         + "\nwith expected Aggregated Object TestCaseFinishedEventId:\n"
@@ -144,7 +144,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
     public void perform_invalid_query_on_created_aggregated_object() throws Throwable {
         final String invalidDocumentId = "6acc3c87-75e0-4aaa-88f5-b1a5d4e6cccc";
         final String entryPoint = "/queryAggregatedObject";
-        final String expectedResponse = "{\"responseEntity\":\"[]\"}";
+        final String expectedResponse = "";
 
         LOGGER.debug("Trying an invalid query on /queryAggregatedObject RestApi with invalid documentId: "
                 + invalidDocumentId);
@@ -158,7 +158,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
         LOGGER.debug("Response of /queryAggregatedObject RestApi, Status Code: " + responseStatusCode + "\nResponse: "
                 + responseAsString);
 
-        assertEquals(HttpStatus.OK.toString(), Integer.toString(responseStatusCode));
+        assertEquals(HttpStatus.NO_CONTENT.value(), responseStatusCode);
         assertEquals("Differences between actual Aggregated Object:\n" + responseAsString
                 + "\nand expected Aggregated Object:\n" + expectedResponse, expectedResponse, responseAsString);
     }
@@ -197,7 +197,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
             String actualAggrObjId = aggrObjResponse.get("id").asText();
             LOGGER.debug("AggregatedObject id from Response: " + actualAggrObjId);
 
-            assertEquals(HttpStatus.OK.toString(), Integer.toString(response.getStatusCodeValue()));
+            assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
             assertEquals(
                     "Failed to compare actual Aggregated Object Id:\n" + actualAggrObjId
                             + "\nwith expected Aggregated Object Id:\n" + expectedAggrId,
@@ -210,7 +210,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
         final String invalidAggrId = "6acc3c87-75e0-4b6d-88f5-b1aee4e62b43";
         final String entryPoint = "/query";
         final String queryAggrObj = "{\"criteria\" :{\"aggregatedObject.id\" : \"" + invalidAggrId + "\" }}";
-        final String expectedResponse = "[]";
+        final String expectedResponse = "";
 
         LOGGER.debug("Trying an invalid query on /query RestApi with invalid criteria query: " + queryAggrObj);
 
@@ -223,7 +223,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
         LOGGER.debug(
                 "Response of /query RestApi, Status Code: " + responseStatusCode + "\nResponse: " + responseAsString);
 
-        assertEquals(HttpStatus.OK.toString(), Integer.toString(responseStatusCode));
+        assertEquals(HttpStatus.NO_CONTENT.value(), responseStatusCode);
         assertEquals("Differences between actual Aggregated Object:\n" + responseAsString
                 + "\nand expected Aggregated Object:\n" + expectedResponse, expectedResponse, responseAsString);
     }
@@ -264,7 +264,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
 
         String actualTestCaseStartedEventId = responseEntityFormattedJsonNode.get("testCaseExecutions")
                 .get("testCaseStartedEventId").asText();
-        assertEquals(HttpStatus.OK.toString(), Integer.toString(response.getStatusCodeValue()));
+        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals("Differences between actual Missed Notification response TestCaseStartedEventId:\n"
                 + actualTestCaseStartedEventId
                 + "\nand expected  Missed Notification response TestCaseStartedEventId:\n"
@@ -291,7 +291,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
         LOGGER.debug("Response of /queryMissedNotifications RestApi, Status Code: " + responseStatusCode + "\nResponse: "
                 + responseAsString);
 
-        assertEquals(HttpStatus.OK.toString(), Integer.toString(responseStatusCode));
+        assertEquals(HttpStatus.OK.value(), responseStatusCode);
         assertEquals(
                 "Differences between actual Missed Notification response:\n" + responseAsString
                         + "\nand expected  Missed Notification response:\n" + expectedResponse,
@@ -326,7 +326,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
             String responseAsString = response.getBody().toString();
             int responseStatusCode = response.getStatusCodeValue();
 
-            assertEquals(HttpStatus.OK.toString(), Integer.toString(responseStatusCode));
+            assertEquals(HttpStatus.OK.value(), responseStatusCode);
             assertEquals(
                     "Failed to compare actual response:\n" + responseAsString + "\nwith expected response:\n"
                             + expectedResponse,
@@ -374,7 +374,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
             String responseAsString = response.getBody().toString();
             int responseStatusCode = response.getStatusCodeValue();
 
-            assertEquals(HttpStatus.OK.toString(), Integer.toString(responseStatusCode));
+            assertEquals(HttpStatus.OK.value(), responseStatusCode);
             assertEquals(
                     "Failed to compare actual response:\n" + responseAsString + "\nwith expected response:\n"
                             + expectedResponses.get(pos),
@@ -413,7 +413,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
 
         JsonNode confidenceLevels = aggrObjResponse.get("confidenceLevels").get(1);
 
-        assertEquals(HttpStatus.OK.toString(), Integer.toString(response.getStatusCodeValue()));
+        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals("Failed to retrieve the latest confidence level.", "readyForDelivery",
                 confidenceLevels.get("name").asText());
         assertEquals("Failed to retrieve the latest confidence level.", "SUCCESS",

--- a/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
@@ -48,11 +48,18 @@ public class QueryAggregatedObjectControllerImpl implements QueryAggregatedObjec
      */
     public ResponseEntity<QueryResponse> getQueryAggregatedObject(@RequestParam("ID") final String id) {
         QueryResponse queryResponse = new QueryResponse();
+        String emptyResponseContent = "[]";
+        HttpStatus httpStatus;
         try {
             List<String> response = processAggregatedObject.processQueryAggregatedObject(id);
             queryResponse.setResponseEntity(response.toString());
             LOGGER.debug("The response is: " + response.toString());
-            return new ResponseEntity<>(queryResponse, HttpStatus.OK);
+            if(!queryResponse.getResponseEntity().equalsIgnoreCase(emptyResponseContent)) {
+                httpStatus = HttpStatus.OK;
+            } else {
+                httpStatus = HttpStatus.NO_CONTENT;
+            }
+            return new ResponseEntity<>(queryResponse, httpStatus);
         } catch (Exception e) {
             String errorMessage = "Failed to extract the aggregated data from the Aggregated Object based on ID "
                 + id + ". Error message:\n" + e.getMessage();

--- a/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
@@ -51,6 +51,8 @@ public class QueryControllerImpl implements QueryController {
     @CrossOrigin
     @ApiOperation(value = "")
     public ResponseEntity<?> createQuery(@RequestBody final QueryBody body) {
+        String emptyResponseContent = "[]";
+        HttpStatus httpStatus;
         try {
             JSONObject criteria = new JSONObject(body.getCriteria().getAdditionalProperties());
             JSONObject options = null;
@@ -63,7 +65,12 @@ public class QueryControllerImpl implements QueryController {
             }
 
             JSONArray result = processQueryParams.filterFormParam(criteria, options, filter);
-            return new ResponseEntity<>(result.toString(), HttpStatus.OK);
+            if(!result.toString().equalsIgnoreCase(emptyResponseContent)) {
+                httpStatus = HttpStatus.OK;
+            } else {
+                httpStatus = HttpStatus.NO_CONTENT;
+            }
+            return new ResponseEntity<>(result.toString(), httpStatus);
         } catch (Exception e) {
             String errorMessage = "Failed to extract data from the Aggregated Object using freestyle query. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);


### PR DESCRIPTION
### Applicable Issues
Required for pull request:
https://github.com/eiffel-community/eiffel-intelligence-frontend/pull/143

Intention is to change the check of the "empty" string to a check of the response code which is much cleaner and easier.
### Description of the Change
When no match is found in query, response code 204 will be returned.

### Alternate Designs

### Benefits
It's easier to detect if the query has failed by simply checking the response code rather than checking the response body.

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
