### PR TITLE
Dockerfile for building images for Docker and Kubernetes

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Eiffel-Community
 
 ARG URL
 RUN echo echo Bulding Eiffel-Intelligence image based on artifact url: ${URL}
-EXPOSE 8091 8778 9779
 
 # Create image with existing war file. User need to execute 'mvn package -DskipTest' before 'docker build'
 RUN ["rm", "-fr", "/usr/local/tomcat/webapps/ROOT"]

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG URL
 RUN echo Building Eiffel-Intelligence image based on artifact url: ${URL}
 
 # Create image with existing war file. User need to execute 'mvn package -DskipTest' before 'docker build'
-RUN ["rm", "-rf", "/usr/local/tomcat/webapps/ROOT"]
+RUN ["rm -rf /usr/local/tomcat/webapps/ROOT"]
 ADD ./src/main/docker/health-check.sh  /eiffel/health-check.sh
 ADD ./src/main/docker/start-service.sh /eiffel/start-service.sh
 ADD ${URL} /usr/local/tomcat/webapps/ROOT.war

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.0-jre8
 MAINTAINER Eiffel-Community
 
 ARG URL
-RUN echo echo Bulding Eiffel-Intelligence image based on artifact url: ${URL}
+RUN echo Building Eiffel-Intelligence image based on artifact url: ${URL}
 
 # Create image with existing war file. User need to execute 'mvn package -DskipTest' before 'docker build'
 RUN ["rm", "-rf", "/usr/local/tomcat/webapps/ROOT"]

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,13 +1,16 @@
-FROM fabric8/java-jboss-openjdk8-jdk:1.2
+FROM tomcat:8.0-jre8
 MAINTAINER Eiffel-Community
-USER root
-ENV JAVA_APP_DIR=/deployments
-ENV JAVA_APP_JAR=eiffel-intelligence.war
+
+ARG URL
+RUN echo echo Bulding Eiffel-Intelligence image based on artifact url: ${URL}
 EXPOSE 8091 8778 9779
 
 # Create image with existing war file. User need to execute 'mvn package -DskipTest' before 'docker build'
-COPY ./target/eiffel-intelligence-*.war /deployments/eiffel-intelligence.war
+RUN ["rm", "-fr", "/usr/local/tomcat/webapps/ROOT"]
+ADD ./src/main/docker/health-check.sh  /eiffel/health-check.sh
+ADD ./src/main/docker/start-service.sh /eiffel/start-service.sh
+ADD ${URL} /usr/local/tomcat/webapps/ROOT.war
 
-CMD /deployments/run-java.sh
+EXPOSE 8091 8778 9779
 
-
+CMD ["/eiffel/start-service.sh"]

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG URL
 RUN echo Building Eiffel-Intelligence image based on artifact url: ${URL}
 
 # Create image with existing war file. User need to execute 'mvn package -DskipTest' before 'docker build'
-RUN ["rm -rf /usr/local/tomcat/webapps/ROOT"]
+RUN ["rm", "-fr", "/usr/local/tomcat/webapps/ROOT"]
 ADD ./src/main/docker/health-check.sh  /eiffel/health-check.sh
 ADD ./src/main/docker/start-service.sh /eiffel/start-service.sh
 ADD ${URL} /usr/local/tomcat/webapps/ROOT.war

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -5,11 +5,10 @@ ARG URL
 RUN echo echo Bulding Eiffel-Intelligence image based on artifact url: ${URL}
 
 # Create image with existing war file. User need to execute 'mvn package -DskipTest' before 'docker build'
-RUN ["rm", "-fr", "/usr/local/tomcat/webapps/ROOT"]
+RUN ["rm", "-rf", "/usr/local/tomcat/webapps/ROOT"]
 ADD ./src/main/docker/health-check.sh  /eiffel/health-check.sh
 ADD ./src/main/docker/start-service.sh /eiffel/start-service.sh
 ADD ${URL} /usr/local/tomcat/webapps/ROOT.war
 
-EXPOSE 8091 8778 9779
 
 CMD ["/eiffel/start-service.sh"]

--- a/src/main/docker/README.txt
+++ b/src/main/docker/README.txt
@@ -5,7 +5,7 @@ docker build -t eiffel-intelligence:0.0.19 --build-arg URL=https://jitpack.io/co
 
 
 B: Build Eiffel-Intelligence based on local Eiffel-Intelligence source code changes
-1. Build Eiffel-Intelligence service artiface:
+1. Build Eiffel-Intelligence service artifact:
 cd (git root dir)
 mvn package -DskipTests
 

--- a/src/main/docker/README.txt
+++ b/src/main/docker/README.txt
@@ -1,0 +1,14 @@
+A: Build Eiffel-Intelligence Docker image based on Eiffel-Intelligence from an Artifactory, e.g. Jitpack:
+cd (git root dir)
+docker build -t eiffel-intelligence:0.0.19 --build-arg URL=https://jitpack.io/com/github/eiffel-community/eiffel-intelligence/0.0.19/eiffel-intelligence-0.0.19.war -f src/main/docker/Dockerfile .
+
+
+
+B: Build Eiffel-Intelligence based on local Eiffel-Intelligence source code changes
+1. Build Eiffel-Intelligence service artiface:
+cd (git root dir)
+mvn package -DskipTests
+
+2. Build Eiffel-Intelligence Docker image:
+cd (git root dir)/
+docker build -t eiffel-intelligence:0.0.19 --build-arg URL=./target/eiffel-intelligence-0.0.19.war -f src/main/docker/Dockerfile .

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -112,7 +112,7 @@ services:
        - mongodb.externalERs
        - search.limit=100
        - search.levels=10
-       - eventrepo2.URL=https://eiffel.lmera.ericsson.se/com.ericsson.duraci/eiffel-erri/index.html
+       - eventrepo2.URL=
        - index.staticIndex.indexOn=false
        - index.staticIndex.filePath=src/main/resources/static_indexes.json
        - index.dynamicIndex.indexOn=false

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 #################################################################################################
 #
-# Copyright 2018 Ericsson AB.
+# Copyright 2019 Ericsson AB.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 ##################################################################################################
-# Eiffel Sandbox 
+# docker-compose commands 
 #
 # run:         docker-compose up         
 # stop:        docker-compose stop
@@ -27,7 +27,7 @@
 #     Unused Images:      docker images -q | xargs docker rmi
 #     Stopped containers: docker rm `docker ps -a -q` 
 #
-# Maintainer: michael.frick@ericsson.com
+# Maintainer: Eiffel-Community
 ##################################################################################################
 version: "2.1"
 services:

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -1,0 +1,168 @@
+#################################################################################################
+#
+# Copyright 2018 Ericsson AB.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##################################################################################################
+# Eiffel Sandbox 
+#
+# run:         docker-compose up         
+# stop:        docker-compose stop
+# stop/remove: docker-compose down --volumes
+#
+# Cleanup/Remove (if needed):
+#     Dangling Volumes:   docker volume rm `docker volume ls -q -f dangling=true`            
+#     Unused Images:      docker images -q | xargs docker rmi
+#     Stopped containers: docker rm `docker ps -a -q` 
+#
+# Maintainer: michael.frick@ericsson.com
+##################################################################################################
+version: "2.1"
+services:
+  mongodb:
+    restart: always
+    image: mongo:latest
+    expose:
+      - "27017"
+    ports:
+      - "27017:27017"
+    healthcheck: 
+        test: ["CMD-SHELL","echo", "'db.stats().ok' | mongo localhost:27017/test", "--quiet"]
+        interval: 30s
+        timeout: 10s
+        retries: 5        
+    networks:
+          eiffel_2.0_1:
+            aliases:
+              - mongodb
+
+  rabbitmq:
+    restart: always
+    image: rabbitmq:3.6.2-management
+    expose:
+      - "15672"
+      - "5672"
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+    healthcheck:
+        test: ["CMD-SHELL", "if rabbitmqctl status; then \nexit 0 \nfi \nexit 1"]
+        interval: 30s
+        timeout: 10s
+        retries: 5
+    networks:
+          eiffel_2.0_1:
+            aliases:
+              - rabbitmq
+    environment:
+      - RABBITMQ_DEFAULT_PASS=myuser
+      - RABBITMQ_DEFAULT_USER=myuser
+      - RABBITMQ_DEFAULT_VHOST=/
+
+  eiffel-er:
+    restart: always
+    image: eiffelericsson/eiffel-er:0.0.60
+    expose:
+      - "8080"
+    ports:
+      - "8081:8080"
+    depends_on:
+      - rabbitmq
+      - mongodb
+    networks:
+          eiffel_2.0_1:
+            aliases:
+              - eiffel-er
+    environment:   # Overrides settings in config file in catalina folder. OBS --> skip quotes for rabbitmq.bindingKey value  
+                   # No config file copied to catalina folder in Dockerfile, only uses env vars below ;-)
+                   # /eventrepository removed in contextpath
+       - server.contextPath=/
+       - server.port=8080
+       - rabbitmq.host=rabbitmq
+       - rabbitmq.componentName=eventrepository
+       - rabbitmq.port=5672
+       - rabbitmq.domainId=ei-domain
+       - rabbitmq.durable=true
+       - rabbitmq.user=myuser
+       - rabbitmq.password=myuser
+       - rabbitmq.exchangeName=ei-exchange
+       - rabbitmq.bindingKey=#
+       - rabbitmq.autoDelete=false
+       - rabbitmq.createExchangeIfNotExisting=true
+       - rabbitmq.consumerName=messageConsumer
+       - mongodb.host=mongodb
+       - mongodb.port=27017
+       - mongodb.database=eiffel
+       - mongodb.collection=events
+       - mongodb.user
+       - mongodb.password
+       - mongodb.indexes=meta.id,links.target,links.type,meta.time,data.gav.groupId,data.gav.artifactId
+       - mongodb.externalERs
+       - search.limit=100
+       - search.levels=10
+       - eventrepo2.URL=https://eiffel.lmera.ericsson.se/com.ericsson.duraci/eiffel-erri/index.html
+       - index.staticIndex.indexOn=false
+       - index.staticIndex.filePath=src/main/resources/static_indexes.json
+       - index.dynamicIndex.indexOn=false
+       - index.dynamicIndex.indexCreationDay=SUNDAY
+       - index.dynamicIndex.indexCreationTime=11:50:00
+       - index.dynamicIndex.maxIndexesCount=5
+       - index.dynamicIndex.filePath=src/main/resources/dynamic_indexing.json
+       - index.dynamicIndex.fileUpdatePeriod=30
+
+  ei_backend:
+    restart: always
+    image: eiffel-intelligence:0.0.19
+    expose:
+      - "8080"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongodb
+      - rabbitmq
+    networks:
+          eiffel_2.0_1:
+            aliases:
+              - ei_backend
+    environment:       # Overrides settings in application config file
+      - SpringApplicationName=ei-backend
+      - server.port=8080
+      - rules.path=src/main/resources/ArtifactRules_new.json
+      - rabbitmq.host=rabbitmq
+      - rabbitmq.port=5672
+      - rabbitmq.domainId=ei-domain
+      - rabbitmq.componentName=ei-backend
+      - rabbitmq.waitlist.queue.suffix=waitlist
+      - rabbitmq.exchange.name=ei-exchange
+      - rabbitmq.user=myuser
+      - rabbitmq.password=myuser
+      - spring.data.mongodb.host=mongodb
+      - spring.data.mongodb.port=27017
+      - spring.data.mongodb.database=eiffel2_intelligence
+      - missedNotificationDataBaseName=eiffel2_intelligence_MissedNotification
+      - search.query.prefix=object
+      - aggregated.object.name=aggregatedObject
+      - spring.mail.host=
+      - spring.mail.port=
+      - spring.mail.username=
+      - spring.mail.password=
+      - spring.mail.properties.mail.smtp.auth=false
+      - spring.mail.properties.mail.smtp.starttls.enable=false
+      - er.url=eiffel-er:8080
+      - WAIT_MB_HOSTS=rabbitmq:15672
+      - WAIT_DB_HOSTS=mongodb:27017
+
+networks:
+  eiffel_2.0_1:

--- a/src/main/docker/health-check.sh
+++ b/src/main/docker/health-check.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#NC_BIN=nc.traditional
+#NC_BIN=nc
+SLEEP_LENGTH=8
+
+WAIT_HOSTS="${@}"
+
+echo "Will wait for fallowing hosts getting started:"
+echo "${WAIT_HOSTS}"
+
+wait_for_service() {
+  echo Waiting for $1 to listen on $2...
+   LOOP=1
+   while [ "$LOOP" != "0" ];
+     do
+     echo "Waiting on host: ${1}:${2}"
+     sleep $SLEEP_LENGTH
+     curl $1:$2
+     RESULT=$?
+     echo "Service check result: $RESULT"
+     if [ $RESULT == 0  ]
+     then
+       LOOP=0
+     fi
+     done
+}
+
+echo
+echo "Waiting for components to start"
+echo
+
+for URL in `echo "${WAIT_HOSTS}"`
+do
+  wait_for_service `echo $URL | sed s/\:/\ /`
+  echo "Host $URL detected started."
+done
+
+echo
+echo "All services detected as started."
+echo
+
+exit 0

--- a/src/main/docker/start-service.sh
+++ b/src/main/docker/start-service.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# These two varibales need to be set from Docker-compose or K8S at startup if MB and/or DB healthcheck should be used.
+#WAIT_MB_HOSTS="localhost:15672 localhost:15672"
+
+if [ ! -z "$WAIT_MB_HOSTS" ]
+then
+  /eiffel/health-check.sh "$WAIT_MB_HOSTS"
+fi
+
+if [ ! -z "$WAIT_DB_HOSTS" ]
+then
+  /eiffel/health-check.sh "$WAIT_DB_HOSTS"
+fi
+
+
+echo
+echo "Starting Eiffel-Intelligence"
+echo
+
+/eiffel/health-check.sh && catalina.sh run

--- a/src/main/docker/start-service.sh
+++ b/src/main/docker/start-service.sh
@@ -18,4 +18,4 @@ echo
 echo "Starting Eiffel-Intelligence"
 echo
 
-/eiffel/health-check.sh && catalina.sh run
+catalina.sh run

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -33,7 +33,7 @@ Now docker image has build with tag "eiffel-intelligence-backend:0.1"
 To run the produced docker image on the local Docker host, execute this command: 
 
 
-`docker run --network -p 8070:8080 --expose 8080 -e server.port=8080 -e logging.level.log.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG -e spring.data.mongodb.host=eiffel2-mongodb -e spring.data.mongodb.port=27017 eiffel-intelligence:0.0.19`
+`docker run -p 8070:8080 --expose 8080 -e server.port=8080 -e logging.level.log.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG -e spring.data.mongodb.host=eiffel2-mongodb -e spring.data.mongodb.port=27017 eiffel-intelligence:0.0.19`
 
 # Some info of all flags to this command
 

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -24,7 +24,7 @@ This will produce a war file in the "target" folder.
 2. Build the Docker image with the war file that was produced from previous step: 
 
 
-`docker build -f src/main/docker/Dockerfile -t eiffel-intelligence-backend:0.1 .` 
+`docker build -t eiffel-intelligence:0.0.19 --build-arg URL=./target/eiffel-intelligence-0.0.19.war -f src/main/docker/Dockerfile .` 
 
 
 Now docker image has build with tag "eiffel-intelligence-backend:0.1"

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -35,6 +35,9 @@ To run the produced docker image on the local Docker host, execute this command:
 
 `docker run -p 8070:8080 --expose 8080 -e server.port=8080 -e logging.level.log.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG -e spring.data.mongodb.host=eiffel2-mongodb -e spring.data.mongodb.port=27017 eiffel-intelligence:0.0.19`
 
+MongoDB, RabbitMq and other Eiffel-Intelligence required components need to running and configured via these application properties that is provided to the docker command above. See the application.properties file for all available/required properties:
+[application.properties](https://github.com/Ericsson/eiffel-intelligence/blob/master/src/main/resources/application.properties)
+
 
 # Some info of all flags to this command
 

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -93,9 +93,13 @@ This docker-compose file includes these components, [docker-compose.yml](https:/
 
 If you have used a different image tag when you build the EI Backend docker image,
 then you need to update docker-compose.yml file.
+
 This line need to changed, in ei_backend service section:
+
 "image: eiffel-intelligence:0.0.19"
+
 To:
+
 "image: \<your image tag\>"
 
 Then run following docker-compose command to startup all components:

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -81,7 +81,7 @@ Another option to configure Eiffel-Intelligence is to provide the application pr
 
 
 # Run Docker image with provided docker-compose file
-This docker-compose file includes these components, src/main/docker/docker-compose.yml:
+This docker-compose file includes these components, [docker-compose.yml](https://github.com/Ericsson/eiffel-intelligence/blob/master/src/main/docker/docker-compose.yml):
 - MongoDb
 - RabbitMq
 - ER
@@ -94,7 +94,7 @@ This line need to changed, in ei_backend service section:
 To:
 "image: \<your image tag\>"
 
-Then run followin docker-compose command to startup all components:
+Then run following docker-compose command to startup all components:
 `docker-compose -f src/main/docker/docker-compose.yml up -d`
 
 It will take some minutes until all components has started. When all components has loaded, you should be able to access EI-Backend Rest-interfaces with address:
@@ -110,3 +110,9 @@ To get the logs from the EI-Backend container/services, example of getting logs 
 
 All service names can be retreived from following command:
 `docker-compose -f src/main/docker/docker-compose.yml config --services`
+
+It is also possible to retrieve the logs by only using "docker logs <container_id or container_name>" command:
+`docker logs \<container_id or container_name\>`
+
+Container id can be retrieved with docker command:
+`docker ps`

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -116,7 +116,7 @@ To get the logs from the EI-Backend container/services, example of getting logs 
 
 `docker-compose -f src/main/docker/docker-compose.yml logs ei_backend`
 
-All service names can be retreived from following command:
+All service names can be retreived with following command:
 
 `docker-compose -f src/main/docker/docker-compose.yml config --services`
 

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -67,12 +67,12 @@ It is possible to set all Spring available properties via docker envrionment "-e
 When Eiffel-Intelligence container is running on your local Docker host, Eiffel-Intelligence should be reachable with address "localhost:8070/\<Rest End-Point\>" or "\<docker host ip\>:8070/\<Rest End-Point\>"
 
 
-Another option to configure Eiffel-Intelligence is with a provided application properties file, which can be made in two ways:
-1. Put application.properties file in Tomcat Catalina config folder and run Eiffe-Intelligence:
+Another option to configure Eiffel-Intelligence is to provide the application properties file into the container, which can be made in two ways:
+1. Put application.properties file in Tomcat Catalina config folder in container and run Eiffe-Intelligence:
 
 `docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/usr/local/tomcat/config/application.properties eiffel-intelligence:0.0.19`
 
-2. Put application.properties file in a different folder in container and tell EI where the application.properties is located:
+2. Put application.properties file in a different folder in container and tell EI where the application.properties is located in the container:
 
 `docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/tmp/application.properties -e spring.config.location=/tmp/application.properties eiffel-intelligence:0.0.19`
 

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -33,7 +33,7 @@ Now docker image has build with tag "eiffel-intelligence-backend:0.1"
 To run the produced docker image on the local Docker host, execute this command: 
 
 
-`docker run -p 8034:8091 --expose 8091 -e server.port=8091 -e logging.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG eiffel-intelligence-backend:0.1`
+`docker run --network -p 8070:8080 --expose 8080 -e server.port=8080 -e logging.level.log.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG -e spring.data.mongodb.host=eiffel2-mongodb -e spring.data.mongodb.port=27017 eiffel-intelligence:0.0.19`
 
 # Some info of all flags to this command
 
@@ -41,7 +41,7 @@ To run the produced docker image on the local Docker host, execute this command:
 ## Eiffel Intelligence Spring Properties
 
 
-<B>"-e server.port=8091"</B> - Is the Spring property setting for Eiffel-Intelligence applications web port.
+<B>"-e server.port=8080"</B> - Is the Spring property setting for Eiffel-Intelligence applications web port.
 
 
 <B>"-e logging.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e 
@@ -57,10 +57,10 @@ It is possible to set all Spring available properties via docker envrionment "-e
 ## Docker flags
 
 
-<B>"--expose 8091"</B> - this Docker flag tells that containers internal port shall be exposed to outside of the Docker Host. This flag do not set which port that should be allocated outside Docker Host on the actual server/machine.
+<B>"--expose 8080"</B> - this Docker flag tells that containers internal port shall be exposed to outside of the Docker Host. This flag do not set which port that should be allocated outside Docker Host on the actual server/machine.
 
 
-<B>"-p 8034:8091"</B> - this Docker flag is mapping the containers external port 8034 to the internal exposed port 8091. Port 8034 will be allocated outside Docker host and user will be able to access the containers service via port 8034.
+<B>"-p 8070:8080"</B> - this Docker flag is mapping the containers external port 8034 to the internal exposed port 8091. Port 8034 will be allocated outside Docker host and user will be able to access the containers service via port 8034.
 
 
-When Eiffel-Intelligence container is running on your local Docker host, Eiffel-Intelligence should be reachable with address "localhost:8091/\<Rest End-Point\>" or "\<docker host ip\>:8091/\<Rest End-Point\>"
+When Eiffel-Intelligence container is running on your local Docker host, Eiffel-Intelligence should be reachable with address "localhost:8070/\<Rest End-Point\>" or "\<docker host ip\>:8070/\<Rest End-Point\>"

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -112,7 +112,7 @@ All service names can be retreived from following command:
 `docker-compose -f src/main/docker/docker-compose.yml config --services`
 
 It is also possible to retrieve the logs by only using "docker logs <container_id or container_name>" command:
-`docker logs \<container_id or container_name\>`
+`docker logs <container_id or container_name>`
 
 Container id can be retrieved with docker command:
 `docker ps`

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -95,24 +95,31 @@ To:
 "image: \<your image tag\>"
 
 Then run following docker-compose command to startup all components:
+
 `docker-compose -f src/main/docker/docker-compose.yml up -d`
 
 It will take some minutes until all components has started. When all components has loaded, you should be able to access EI-Backend Rest-interfaces with address:
 http://localhost:8080/\<EI rest-api endpoint\>
 
 Curl command can be used to make request to EI-Back-end rest-api, example for getting all subscriptions:
+
+
 `curl -X GET http://localhost:8080/subscriptions`
 
 It is also possible to access these address in web-browser and get result present in a Json view in web-browser.
 
 To get the logs from the EI-Backend container/services, example of getting logs from ei_backend service:
+
 `docker-compose -f src/main/docker/docker-compose.yml logs ei_backend`
 
 All service names can be retreived from following command:
+
 `docker-compose -f src/main/docker/docker-compose.yml config --services`
 
 It is also possible to retrieve the logs by only using "docker logs <container_id or container_name>" command:
+
 `docker logs <container_id or container_name>`
 
 Container id can be retrieved with docker command:
+
 `docker ps`

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -114,9 +114,9 @@ Curl command can be used to make request to EI-Back-end rest-api, example for ge
 
 `curl -X GET http://localhost:8080/subscriptions`
 
-It is also possible to access these address in web-browser and get result present in a Json view in web-browser.
+It is also possible to access these Rest-Api addresses in web-browser and get result present in a Json view in web-browser.
 
-To get the logs from the EI-Backend container/services, example of getting logs from ei_backend service:
+Following command can be used to get the logs from the EI-Backend container/service:
 
 `docker-compose -f src/main/docker/docker-compose.yml logs ei_backend`
 

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -35,6 +35,7 @@ To run the produced docker image on the local Docker host, execute this command:
 
 `docker run -p 8070:8080 --expose 8080 -e server.port=8080 -e logging.level.log.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG -e spring.data.mongodb.host=eiffel2-mongodb -e spring.data.mongodb.port=27017 eiffel-intelligence:0.0.19`
 
+
 # Some info of all flags to this command
 
 
@@ -64,3 +65,12 @@ It is possible to set all Spring available properties via docker envrionment "-e
 
 
 When Eiffel-Intelligence container is running on your local Docker host, Eiffel-Intelligence should be reachable with address "localhost:8070/\<Rest End-Point\>" or "\<docker host ip\>:8070/\<Rest End-Point\>"
+
+
+Another option to configure Eiffel-Intelligence is with a provided application properties file, which can be made in two ways:
+1. Put application.properties file in Tomcat Catalina config folder and run Eiffe-Intelligence:
+`docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/usr/local/tomcat/application.properties eiffel-intelligence:0.0.19`
+
+2. Put application.properties file in a different folder in container and tell EI where the application.properties is located:
+`docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/tmp/application.properties -e spring.config.location=/tmp/application.properties eiffel-intelligence:0.0.19`
+

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -12,6 +12,10 @@ With the Docker image user can try-out the Eiffel-Intelligence on a Docker Host 
   
   Windows: https://docs.docker.com/docker-for-windows/install/
 
+- Docker Compose
+  
+  Linux and Windows:  https://docs.docker.com/compose/install/
+
 ## Follow these step to build the Docker image.
 
 1. Build the Eiffel-intelligence war file: 

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -69,7 +69,7 @@ When Eiffel-Intelligence container is running on your local Docker host, Eiffel-
 
 Another option to configure Eiffel-Intelligence is with a provided application properties file, which can be made in two ways:
 1. Put application.properties file in Tomcat Catalina config folder and run Eiffe-Intelligence:
-`docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/usr/local/tomcat/application.properties eiffel-intelligence:0.0.19`
+`docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/usr/local/tomcat/config/application.properties eiffel-intelligence:0.0.19`
 
 2. Put application.properties file in a different folder in container and tell EI where the application.properties is located:
 `docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/tmp/application.properties -e spring.config.location=/tmp/application.properties eiffel-intelligence:0.0.19`

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -69,8 +69,10 @@ When Eiffel-Intelligence container is running on your local Docker host, Eiffel-
 
 Another option to configure Eiffel-Intelligence is with a provided application properties file, which can be made in two ways:
 1. Put application.properties file in Tomcat Catalina config folder and run Eiffe-Intelligence:
+
 `docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/usr/local/tomcat/config/application.properties eiffel-intelligence:0.0.19`
 
 2. Put application.properties file in a different folder in container and tell EI where the application.properties is located:
+
 `docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/tmp/application.properties -e spring.config.location=/tmp/application.properties eiffel-intelligence:0.0.19`
 

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -79,3 +79,34 @@ Another option to configure Eiffel-Intelligence is to provide the application pr
 
 `docker run -p 8070:8080 --expose 8080 --volume /path/to/application.properties:/tmp/application.properties -e spring.config.location=/tmp/application.properties eiffel-intelligence:0.0.19`
 
+
+# Run Docker image with provided docker-compose file
+This docker-compose file includes these components, src/main/docker/docker-compose.yml:
+- MongoDb
+- RabbitMq
+- ER
+- EI-Backend (Using the local EI-Backend Docker image build from previous steps)
+
+If you have used a different image tag when you build the EI Backend docker image,
+then you need to update docker-compose.yml file.
+This line need to changed, in ei_backend service section:
+"image: eiffel-intelligence:0.0.19"
+To:
+"image: \<your image tag\>"
+
+Then run followin docker-compose command to startup all components:
+`docker-compose -f src/main/docker/docker-compose.yml up -d`
+
+It will take some minutes until all components has started. When all components has loaded, you should be able to access EI-Backend Rest-interfaces with address:
+http://localhost:8080/\<EI rest-api endpoint\>
+
+Curl command can be used to make request to EI-Back-end rest-api, example for getting all subscriptions:
+`curl -X GET http://localhost:8080/subscriptions`
+
+It is also possible to access these address in web-browser and get result present in a Json view in web-browser.
+
+To get the logs from the EI-Backend container/services, example of getting logs from ei_backend service:
+`docker-compose -f src/main/docker/docker-compose.yml logs ei_backend`
+
+All service names can be retreived from following command:
+`docker-compose -f src/main/docker/docker-compose.yml config --services`


### PR DESCRIPTION
### Description of the Change
Adding a Dockerfile so user can build Docker image for Docker and Kubernetes.

### Benefits
Make it easy to build Eiffel-Intelligence docker images.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
