### PR TITLE
Fix copy of png files during site generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
             <artifactId>httpcore</artifactId>
             <version>4.4.9</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
@@ -358,7 +358,7 @@
                 <version>${springBootVersion}</version>
             </plugin>
 
-            <!-- PhoenixNAP RAML Code Generator plugin used to generate sources 
+            <!-- PhoenixNAP RAML Code Generator plugin used to generate sources
                 from raml -->
             <plugin>
                 <groupId>com.phoenixnap.oss</groupId>
@@ -462,26 +462,26 @@
                              <goal>integration-test</goal>
                              <goal>verify</goal>
                          </goals>
-                         <phase>integration-test</phase>                          
+                         <phase>integration-test</phase>
                      </execution>
                  </executions>
                  <configuration>
-	                 <forkCount>3</forkCount>
-	                 <reuseForks>false</reuseForks>
-	                 <skipTests>${skipTests}</skipTests>
-	                 <skipITs>${skipITs}</skipITs>
-	                 <systemPropertyVariables>
-	                     <systemTest>true</systemTest>
-	                     <er.url>http://localhost:8080/eventrepository/search/</er.url>
-	                 </systemPropertyVariables>
-	                 <excludes>
-	                     <exclude>**/test/*</exclude>
-	                     <exclude>**/functionaltests/*</exclude>
-	                 </excludes>
-	                  <additionalClasspathElements>
-	                     <additionalClasspathElement>${basedir}/target/classes</additionalClasspathElement>
-	                 </additionalClasspathElements>
-	             </configuration>
+                     <forkCount>3</forkCount>
+                     <reuseForks>false</reuseForks>
+                     <skipTests>${skipTests}</skipTests>
+                     <skipITs>${skipITs}</skipITs>
+                     <systemPropertyVariables>
+                         <systemTest>true</systemTest>
+                         <er.url>http://localhost:8080/eventrepository/search/</er.url>
+                     </systemPropertyVariables>
+                     <excludes>
+                         <exclude>**/test/*</exclude>
+                         <exclude>**/functionaltests/*</exclude>
+                     </excludes>
+                      <additionalClasspathElements>
+                         <additionalClasspathElement>${basedir}/target/classes</additionalClasspathElement>
+                     </additionalClasspathElements>
+                 </configuration>
               </plugin>
 
             <plugin>
@@ -500,7 +500,7 @@
                 <configuration>
                     <!-- This is where site.xml is located -->
                     <siteDirectory>${basedir}/wiki</siteDirectory>
-                    <!-- Github pages only generates documentation from docs 
+                    <!-- Github pages only generates documentation from docs
                         directory -->
                     <outputDirectory>${basedir}/docs</outputDirectory>
                 </configuration>
@@ -525,13 +525,16 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <!-- plugin requires all resources to exist within 
+                            <!-- plugin requires all resources to exist within
                                 resources/ directory -->
                             <!-- but we don't want to break links in documentation -->
                             <outputDirectory>${basedir}/wiki/resources/images</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${basedir}/wiki/markdown/images</directory>
+                                    <includes>
+                                        <include>**/*.png</include>
+                                    </includes>
                                 </resource>
                             </resources>
                         </configuration>
@@ -542,7 +545,7 @@
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.1.0</version>
-                <!-- We want to remove duplicate/copied resources from site 
+                <!-- We want to remove duplicate/copied resources from site
                     generation -->
                 <configuration>
                     <filesets>


### PR DESCRIPTION
### Applicable Issues
The png files were not copied during site generation, causing the images to not exist in the docs/ directory.

### Description of the Change
Explicitly telling the resource plugin to include all .png files solves the issue.

### Benefits
Images included in the site documentation, as they should be.

### Sign-off


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
