### PR TITLE
Removed mvn clean command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ script:
 before_deploy:
   - rm -rf docs
   - mvn site -B
-  - mvn clean -B
 
 deploy:
   skip_cleanup: true

--- a/pom.xml
+++ b/pom.xml
@@ -533,7 +533,7 @@
                                 <resource>
                                     <directory>${basedir}/wiki/markdown/images</directory>
                                     <includes>
-                                        <include>**/*.png</include>
+                                        <include>*.png</include>
                                     </includes>
                                 </resource>
                             </resources>
@@ -542,19 +542,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.1.0</version>
-                <!-- We want to remove duplicate/copied resources from site
-                    generation -->
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${basedir}/wiki/resources</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### Applicable Issues
We've changed the copy of resources during site generation, and when cleaning the repository the copied images are deleted before site generation.

### Description of the Change
Removed configuration of the clean plugin. Also removed the mvn clean command from site generation in travis job.

### Benefits
Visible images in the site docs...

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
