### PR TITLE
Add stages in travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,32 +8,58 @@ services:
 jdk:
   - oraclejdk8
 
+# Run before every job
 before_install:
   - uname -a
   - chmod +x pom.xml
 
-script:
-# since we run parallel tests using embedded mongodb in fresh environment all tests run first in parallel
-# will try to download the embedded mongo to this travis instance but the late ones will fail to write.
-# We will therefore run one test using mongodb first that will download the mongo instance and
-# then the rest of the test that will no longer need to download the embedded mongo since it will exist.
-#
-# It is also important that the first test to be run is a Spring Boot Test since spring boot also downloads
-# another version of embedded mongo db so all Spring Boot tests will end up in a race condition also
-  -  source docker-env.bash
-  -  docker-compose up -d
-  -  mvn -DsomeModule.test.includes="**/QueryServiceTest.java" test -DskipITs -B
-  -  mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test -DskipITs -B
-  -  mvn verify -DskipUTs -Der.url=http://localhost:8084/search/ -Drabbitmq.exchange.name=ei-exchange -Dspring.mail.host=localhost -Dspring.mail.port=1025 -Dwaitlist.fixedRateResend=1 -B
 
+# This is only run before integrationTests job
+# To ensure docker containers are fully up and running we sleep 20s
+before_script:
+  - source docker-env.bash
+  - docker-compose up -d
+  - sleep 20
+
+
+# Generate site documentation using mvn site plugin
 before_deploy:
   - rm -rf docs
   - mvn site -B
 
-deploy:
-  skip_cleanup: true
-  provider: pages
-  github-token: $GITHUB_TOKEN
-  local_dir: docs/
-  on:
-    branch: master
+
+# Using default stage 'test' for all our test jobs, and only running deploy stage
+# (after merge) to master branch
+stages:
+  - test
+  - name: deploy
+    if: branch = master
+
+
+# List of jobs to run, tied to specific stages
+jobs:
+  include:
+    - stage: test
+      name: functionalTests
+      before_script: skip
+      script:
+        # We will run one test using embedded mongodb first that will download the mongo instance and
+        # then the rest of the test that will no longer need to download the embedded mongo since it will exist.
+        #
+        # Also important that the first test to be run is a Spring Boot Test since spring boot also downloads
+        # another version of embedded mongo db to avoid race conditions between Spring Boot tests
+        - mvn -DsomeModule.test.includes="**/QueryServiceTest.java" test -DskipITs -B
+        - mvn -DsomeModule.test.excludes="**/QueryServiceTest.java" test -DskipITs -B
+    - stage: test
+      name: integrationTests
+      script:
+        - mvn verify -DskipUTs -Der.url=http://localhost:8084/search/ -Drabbitmq.exchange.name=ei-exchange -Dspring.mail.host=localhost -Dspring.mail.port=1025 -Dwaitlist.fixedRateResend=1 -B
+    - stage: deploy
+      name: deployGitHubPages
+      script: skip   # do not run default test scripts
+      install: skip  # do not run default mvn install
+      deploy:
+        provider: pages
+        skip_cleanup: true
+        github-token: $GITHUB_TOKEN
+        local_dir: docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,9 @@ jobs:
         - mvn verify -DskipUTs -Der.url=http://localhost:8084/search/ -Drabbitmq.exchange.name=ei-exchange -Dspring.mail.host=localhost -Dspring.mail.port=1025 -Dwaitlist.fixedRateResend=1 -B
     - stage: deploy
       name: deployGitHubPages
-      script: skip   # do not run default test scripts
-      install: skip  # do not run default mvn install
+      before_script: skip   # do not run this on deploy
+      script: skip          # do not run default test scripts
+      install: skip         # do not run default mvn install
       deploy:
         provider: pages
         skip_cleanup: true


### PR DESCRIPTION
### Applicable Issues
Before the functional tests + integration tests + deployment were done in one big job making it hard to overlook the logs in travis.


### Description of the Change
* Grouped different tests into separate jobs, one for functional test and one for integration test. They are run in parallel, and get separate logs.
* Set up env for integration tests into before_script (this is only run before ITs and not other jobs)
* Add labels for the different jobs
* Deployment is in it's own stage (moved condition of only running on branch master, to stage condition instead of job level)
* Add comments to steps in travis file


### Benefits
Better overview of travis jobs. Separated logs which makes it easier to troubleshoot if something goes wrong.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
