### PR TITLE
Fix clean RepeateHandler AggregatedobjectIds log message.

### DIFF
--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -142,8 +142,10 @@ public class SubscriptionService implements ISubscriptionService {
         if (deleteResult) {
             String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
             if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
-                LOG.error("Failed to clean subscription \"" + subscriptionName
-                        + "\" matched AggregatedObjIds from RepeatFlagHandler database");
+                LOG.warn("Subscription  \"" + subscriptionName
+                        + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the removal of subscription,\n"
+                		+ "probably due to subscritpiton has never matched any Aggregated Objects and "
+                        + "no matched aggredgatedObjectsIds has been stored in database for the specific subscription.");
             }
         } else if (doSubscriptionExist(subscriptionName)) {
             String message = "Failed to delete subscription \"" + subscriptionName

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -123,8 +123,8 @@ public class SubscriptionService implements ISubscriptionService {
                 if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
                     LOG.warn("Subscription  \"" + subscriptionName
                             + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the update of the subscription,\n"
-                    		+ "probably due to subscritpiton has never matched any Aggregated Objects and "
-                            + "no matched aggredgatedObjectsIds has been stored in database for the specific subscription.");
+                    		+ "probably due to subscription has never matched any Aggregated Objects and "
+                            + "no matched aggregatedObjectsIds has been stored in database for the specific subscription.");
                 }
             }
 
@@ -146,8 +146,8 @@ public class SubscriptionService implements ISubscriptionService {
             if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
                 LOG.warn("Subscription  \"" + subscriptionName
                         + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the removal of subscription,\n"
-                		+ "probably due to subscritpiton has never matched any Aggregated Objects and "
-                        + "no matched aggredgatedObjectsIds has been stored in database for the specific subscription.");
+                		+ "probably due to subscription has never matched any Aggregated Objects and "
+                        + "no matched aggregatedObjectsIds has been stored in database for the specific subscription.");
             }
         } else if (doSubscriptionExist(subscriptionName)) {
             String message = "Failed to delete subscription \"" + subscriptionName

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -121,7 +121,7 @@ public class SubscriptionService implements ISubscriptionService {
             if (result != null) {
                 String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
                 if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
-                    LOG.warn("Subscription  \"" + subscriptionName
+                    LOG.info("Subscription  \"" + subscriptionName
                             + "\" matched aggregated objects id from repeat flag handler database could not be cleaned during the update of the subscription,\n"
                     		+ "probably due to subscription has never matched any aggregated objects and "
                             + "no matched aggregated objects id has been stored in database for the specific subscription.");
@@ -144,7 +144,7 @@ public class SubscriptionService implements ISubscriptionService {
         if (deleteResult) {
             String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
             if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
-                LOG.warn("Subscription  \"" + subscriptionName
+                LOG.info("Subscription  \"" + subscriptionName
                         + "\" matched aggregated objects id from repeat flag handler database could not be cleaned during the removal of subscription,\n"
                 		+ "probably due to subscription has never matched any aggregated objects and "
                         + "no matched aggregated objects id has been stored in database for the specific subscription.");

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -121,8 +121,10 @@ public class SubscriptionService implements ISubscriptionService {
             if (result != null) {
                 String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
                 if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
-                    LOG.error("Failed to clean subscription \"" + subscriptionName
-                            + "\" matched AggregatedObjIds from RepeatFlagHandler database");
+                    LOG.warn("Subscription  \"" + subscriptionName
+                            + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the update of the subscription,\n"
+                    		+ "probably due to subscritpiton has never matched any Aggregated Objects and "
+                            + "no matched aggredgatedObjectsIds has been stored in database for the specific subscription.");
                 }
             }
 

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -122,9 +122,9 @@ public class SubscriptionService implements ISubscriptionService {
                 String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
                 if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
                     LOG.warn("Subscription  \"" + subscriptionName
-                            + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the update of the subscription,\n"
-                    		+ "probably due to subscription has never matched any Aggregated Objects and "
-                            + "no matched aggregatedObjectsIds has been stored in database for the specific subscription.");
+                            + "\" matched aggregated objects id from repeat flag handler database could not be cleaned during the update of the subscription,\n"
+                    		+ "probably due to subscription has never matched any aggregated objects and "
+                            + "no matched aggregated objects id has been stored in database for the specific subscription.");
                 }
             }
 
@@ -145,9 +145,9 @@ public class SubscriptionService implements ISubscriptionService {
             String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
             if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
                 LOG.warn("Subscription  \"" + subscriptionName
-                        + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the removal of subscription,\n"
-                		+ "probably due to subscription has never matched any Aggregated Objects and "
-                        + "no matched aggregatedObjectsIds has been stored in database for the specific subscription.");
+                        + "\" matched aggregated objects id from repeat flag handler database could not be cleaned during the removal of subscription,\n"
+                		+ "probably due to subscription has never matched any aggregated objects and "
+                        + "no matched aggregated objects id has been stored in database for the specific subscription.");
             }
         } else if (doSubscriptionExist(subscriptionName)) {
             String message = "Failed to delete subscription \"" + subscriptionName


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
When a Subscription is removed, the repeat handler aggregated objects ids should be cleaned.
If a Subscription has never matched any aggregated objects, then no matched aggregated object ids has been stored in database and the clean up of the Subscriptions matched aggregated objects ids produces and error. This error is not a critical error.
The error message has been improved and describe more whats happening.
Log message has been changed to a log warning message instead.

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
