### PR TITLE
Fixed some of RepeatDBHandling of matched Aggregated Objects ids issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: xenial
-
 sudo: required
 
 language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 sudo: required
 
 language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,8 @@ language: java
 services:
   - docker
 
-addons:
-  apt:
-    packages:
-      - openjdk-8-jdk
-
-        #jdk:
-        #  - oraclejdk8
+jdk:
+  - oraclejdk8
 
 # Run before every job
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ language: java
 services:
   - docker
 
+addons:
+  apt:
+    packages:
+      - openjdk-8-jdk
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ addons:
     packages:
       - openjdk-8-jdk
 
-jdk:
-  - oraclejdk8
+        #jdk:
+        #  - oraclejdk8
 
 # Run before every job
 before_install:

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/repeatHandler/SubscriptionRepeatHandlerSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/repeatHandler/SubscriptionRepeatHandlerSteps.java
@@ -144,7 +144,7 @@ public class SubscriptionRepeatHandlerSteps extends FunctionalTestBase {
         processSubscription(subscriptionStrWithTwoMatch, subscriptionWithTwoMatch);
         List<String> resultRepeatFlagHandler = mongoDBHandler.find(dataBaseName, repeatFlagHandlerCollection,
                 subscriptionIdMatchedAggrIdObjQuery);
-        assertEquals(2, resultRepeatFlagHandler.size());
+        assertEquals(1, resultRepeatFlagHandler.size());
         assertEquals("\"" + AGGREGATED_OBJECT_ID + "\"", getAggregatedObjectId(resultRepeatFlagHandler, 0));
         assertEquals("\"" + AGGREGATED_OBJECT_ID + "\"", getAggregatedObjectId(resultRepeatFlagHandler, 1));
     }
@@ -165,7 +165,8 @@ public class SubscriptionRepeatHandlerSteps extends FunctionalTestBase {
      */
     private String getAggregatedObjectId(List<String> resultRepeatFlagHandler, int index) {
         JsonParser parser = new JsonParser();
-        JsonObject jsonObject = parser.parse(resultRepeatFlagHandler.get(index)).getAsJsonObject();
+        JsonObject jsonObject = parser.parse(resultRepeatFlagHandler.get(0)).getAsJsonObject();
+        System.out.println("JSONOBJECT: " + jsonObject.toString());
         JsonObject requirements = jsonObject.get("requirements").getAsJsonObject();
         return requirements.get(String.valueOf(index)).getAsJsonArray().get(0).toString();
     }

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/repeatHandler/SubscriptionRepeatHandlerSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/repeatHandler/SubscriptionRepeatHandlerSteps.java
@@ -166,7 +166,6 @@ public class SubscriptionRepeatHandlerSteps extends FunctionalTestBase {
     private String getAggregatedObjectId(List<String> resultRepeatFlagHandler, int index) {
         JsonParser parser = new JsonParser();
         JsonObject jsonObject = parser.parse(resultRepeatFlagHandler.get(0)).getAsJsonObject();
-        System.out.println("JSONOBJECT: " + jsonObject.toString());
         JsonObject requirements = jsonObject.get("requirements").getAsJsonObject();
         return requirements.get(String.valueOf(index)).getAsJsonArray().get(0).toString();
     }

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -142,8 +142,10 @@ public class SubscriptionService implements ISubscriptionService {
         if (deleteResult) {
             String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
             if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
-                LOG.error("Failed to clean subscription \"" + subscriptionName
-                        + "\" matched AggregatedObjIds from RepeatFlagHandler database");
+                LOG.warn("Subscription  \"" + subscriptionName
+                        + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the removal of subscription,\n"
+                		+ "probably due to subscritpiton has never matched any Aggregated Objects and "
+                        + "no matched aggredgatedObjectsIds has been stored in database for the specific subscription.");
             }
         } else if (doSubscriptionExist(subscriptionName)) {
             String message = "Failed to delete subscription \"" + subscriptionName

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -123,8 +123,8 @@ public class SubscriptionService implements ISubscriptionService {
                 if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
                     LOG.warn("Subscription  \"" + subscriptionName
                             + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the update of the subscription,\n"
-                    		+ "probably due to subscritpiton has never matched any Aggregated Objects and "
-                            + "no matched aggredgatedObjectsIds has been stored in database for the specific subscription.");
+                    		+ "probably due to subscription has never matched any Aggregated Objects and "
+                            + "no matched aggregatedObjectsIds has been stored in database for the specific subscription.");
                 }
             }
 
@@ -146,8 +146,8 @@ public class SubscriptionService implements ISubscriptionService {
             if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
                 LOG.warn("Subscription  \"" + subscriptionName
                         + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the removal of subscription,\n"
-                		+ "probably due to subscritpiton has never matched any Aggregated Objects and "
-                        + "no matched aggredgatedObjectsIds has been stored in database for the specific subscription.");
+                		+ "probably due to subscription has never matched any Aggregated Objects and "
+                        + "no matched aggregatedObjectsIds has been stored in database for the specific subscription.");
             }
         } else if (doSubscriptionExist(subscriptionName)) {
             String message = "Failed to delete subscription \"" + subscriptionName

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -121,7 +121,7 @@ public class SubscriptionService implements ISubscriptionService {
             if (result != null) {
                 String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
                 if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
-                    LOG.warn("Subscription  \"" + subscriptionName
+                    LOG.info("Subscription  \"" + subscriptionName
                             + "\" matched aggregated objects id from repeat flag handler database could not be cleaned during the update of the subscription,\n"
                     		+ "probably due to subscription has never matched any aggregated objects and "
                             + "no matched aggregated objects id has been stored in database for the specific subscription.");
@@ -144,7 +144,7 @@ public class SubscriptionService implements ISubscriptionService {
         if (deleteResult) {
             String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
             if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
-                LOG.warn("Subscription  \"" + subscriptionName
+                LOG.info("Subscription  \"" + subscriptionName
                         + "\" matched aggregated objects id from repeat flag handler database could not be cleaned during the removal of subscription,\n"
                 		+ "probably due to subscription has never matched any aggregated objects and "
                         + "no matched aggregated objects id has been stored in database for the specific subscription.");

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -121,8 +121,10 @@ public class SubscriptionService implements ISubscriptionService {
             if (result != null) {
                 String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
                 if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
-                    LOG.error("Failed to clean subscription \"" + subscriptionName
-                            + "\" matched AggregatedObjIds from RepeatFlagHandler database");
+                    LOG.warn("Subscription  \"" + subscriptionName
+                            + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the update of the subscription,\n"
+                    		+ "probably due to subscritpiton has never matched any Aggregated Objects and "
+                            + "no matched aggredgatedObjectsIds has been stored in database for the specific subscription.");
                 }
             }
 

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -122,9 +122,9 @@ public class SubscriptionService implements ISubscriptionService {
                 String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
                 if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
                     LOG.warn("Subscription  \"" + subscriptionName
-                            + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the update of the subscription,\n"
-                    		+ "probably due to subscription has never matched any Aggregated Objects and "
-                            + "no matched aggregatedObjectsIds has been stored in database for the specific subscription.");
+                            + "\" matched aggregated objects id from repeat flag handler database could not be cleaned during the update of the subscription,\n"
+                    		+ "probably due to subscription has never matched any aggregated objects and "
+                            + "no matched aggregated objects id has been stored in database for the specific subscription.");
                 }
             }
 
@@ -145,9 +145,9 @@ public class SubscriptionService implements ISubscriptionService {
             String subscriptionIdQuery = String.format(SUBSCRIPTION_ID, subscriptionName);
             if (!cleanSubscriptionRepeatFlagHandlerDb(subscriptionIdQuery)) {
                 LOG.warn("Subscription  \"" + subscriptionName
-                        + "\" matched AggregatedObjIds from RepeatFlagHandler database could not be cleaned during the removal of subscription,\n"
-                		+ "probably due to subscription has never matched any Aggregated Objects and "
-                        + "no matched aggregatedObjectsIds has been stored in database for the specific subscription.");
+                        + "\" matched aggregated objects id from repeat flag handler database could not be cleaned during the removal of subscription,\n"
+                		+ "probably due to subscription has never matched any aggregated objects and "
+                        + "no matched aggregated objects id has been stored in database for the specific subscription.");
             }
         } else if (doSubscriptionExist(subscriptionName)) {
             String message = "Failed to delete subscription \"" + subscriptionName

--- a/src/main/java/com/ericsson/ei/subscriptionhandler/RunSubscription.java
+++ b/src/main/java/com/ericsson/ei/subscriptionhandler/RunSubscription.java
@@ -20,6 +20,7 @@ import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.mongodb.DBObject;
 
 import java.util.Iterator;
 
@@ -66,6 +67,7 @@ public class RunSubscription {
         int count_conditions = 0;
 
         int requirementIndex = 0;
+        LOGGER.debug("AGG OBJECT: " + aggregatedObject);
 
         while (requirementIterator.hasNext()) {
 
@@ -73,9 +75,13 @@ public class RunSubscription {
             ObjectMapper objectMapper = new ObjectMapper();
             try {
                 aggrObjJsonNode = objectMapper.readValue(aggregatedObject, JsonNode.class);
+                
+//                DBObject idObj = (DBObject)aggrObjJsonNode.get("_id").get("$oid");
+                LOGGER.debug("AGGREGATED OBJECT ID: " + aggrObjJsonNode.asText());
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);
             }
+            LOGGER.debug("1111111111111111111111111111111111111111111111111111111111111111111111111111111");
 
             String subscriptionName = subscriptionJson.get("subscriptionName").asText();
             String subscriptionRepeatFlag = subscriptionJson.get("repeat").asText();
@@ -91,7 +97,9 @@ public class RunSubscription {
                         + subscriptionName + "\nand has Subscrption Repeat flag set to: " + subscriptionRepeatFlag);
                 break;
             }
-
+            
+            LOGGER.debug("222222222222222222222222222222222222222222222222222222222222222222222222222222222222");
+            
             JsonNode requirement = requirementIterator.next();
 
             LOGGER.info("The fulfilled requirement which condition will check is : " + requirement.toString());

--- a/src/main/java/com/ericsson/ei/subscriptionhandler/RunSubscription.java
+++ b/src/main/java/com/ericsson/ei/subscriptionhandler/RunSubscription.java
@@ -65,23 +65,9 @@ public class RunSubscription {
         boolean conditionFulfilled = false;
         int count_condition_fulfillment = 0;
         int count_conditions = 0;
-
         int requirementIndex = 0;
-        LOGGER.debug("AGG OBJECT: " + aggregatedObject);
 
         while (requirementIterator.hasNext()) {
-
-            JsonNode aggrObjJsonNode = null;
-            ObjectMapper objectMapper = new ObjectMapper();
-            try {
-                aggrObjJsonNode = objectMapper.readValue(aggregatedObject, JsonNode.class);
-                
-//                DBObject idObj = (DBObject)aggrObjJsonNode.get("_id").get("$oid");
-                LOGGER.debug("AGGREGATED OBJECT ID: " + aggrObjJsonNode.asText());
-            } catch (Exception e) {
-                LOGGER.error(e.getMessage(), e);
-            }
-            LOGGER.debug("1111111111111111111111111111111111111111111111111111111111111111111111111111111");
 
             String subscriptionName = subscriptionJson.get("subscriptionName").asText();
             String subscriptionRepeatFlag = subscriptionJson.get("repeat").asText();
@@ -97,8 +83,6 @@ public class RunSubscription {
                         + subscriptionName + "\nand has Subscrption Repeat flag set to: " + subscriptionRepeatFlag);
                 break;
             }
-            
-            LOGGER.debug("222222222222222222222222222222222222222222222222222222222222222222222222222222222222");
             
             JsonNode requirement = requirementIterator.next();
 

--- a/src/main/java/com/ericsson/ei/subscriptionhandler/RunSubscription.java
+++ b/src/main/java/com/ericsson/ei/subscriptionhandler/RunSubscription.java
@@ -18,9 +18,7 @@ package com.ericsson.ei.subscriptionhandler;
 
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.mongodb.DBObject;
 
 import java.util.Iterator;
 

--- a/src/main/java/com/ericsson/ei/subscriptionhandler/SubscriptionRepeatDbHandler.java
+++ b/src/main/java/com/ericsson/ei/subscriptionhandler/SubscriptionRepeatDbHandler.java
@@ -197,7 +197,6 @@ public class SubscriptionRepeatDbHandler {
             return false;
         }
 
-//        String idStr = listAggrObjIds.get(requirementId);
         if (listAggrObjIds.contains(aggrObjId)) {
             LOGGER.debug("Subscription has matched aggrObjId already: " + aggrObjId);
             return true;

--- a/src/main/java/com/ericsson/ei/subscriptionhandler/SubscriptionRepeatDbHandler.java
+++ b/src/main/java/com/ericsson/ei/subscriptionhandler/SubscriptionRepeatDbHandler.java
@@ -26,6 +26,7 @@ import com.mongodb.BasicDBObject;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,7 +96,6 @@ public class SubscriptionRepeatDbHandler {
 
         if (!updateExistingMatchedSubscriptionWithAggrObjId(subscriptionId, requirementId, aggrObjId)) {
             LOGGER.error("Couldn't update SubscriptionMathced id.");
-        } else {
             LOGGER.debug(
                     "New Subscription AggrId has not matched, inserting new SubscriptionId and AggrObjId to matched list.");
             BasicDBObject document = new BasicDBObject();
@@ -120,17 +120,17 @@ public class SubscriptionRepeatDbHandler {
     private boolean updateExistingMatchedSubscriptionWithAggrObjId(String subscriptionId, int requirementId,
             String aggrObjId) throws Exception {
         String subscriptionQuery = "{\"subscriptionId\" : \"" + subscriptionId + "\"}";
-
         JsonNode updateDocJsonNode = mapper.readValue(
                 "{\"$push\" : { \"requirements." + requirementId + "\" : \"" + aggrObjId + "\"}}", JsonNode.class);
-
-        LOGGER.debug("SubscriptionId \"", subscriptionId,
+        LOGGER.debug("SubscriptionId \"", subscriptionId +
                 "\" document will be updated with following requirement update object: "
                         + updateDocJsonNode.toString());
 
         JsonNode queryJsonNode = mapper.readValue(subscriptionQuery, JsonNode.class);
+        
+        Document document = null;
         try {
-            mongoDbHandler.findAndModify(dataBaseName, collectionName, queryJsonNode.toString(),
+            document = mongoDbHandler.findAndModify(dataBaseName, collectionName, queryJsonNode.toString(),
                     updateDocJsonNode.toString());
         } catch (Exception e) {
             LOGGER.debug("Failed to update existing matched SubscriptionId with new AggrId." + "SubscriptionId: "
@@ -138,7 +138,15 @@ public class SubscriptionRepeatDbHandler {
                     + requirementId);
             return false;
         }
-        return true;
+        if (document != null && !document.isEmpty()) {
+            LOGGER.debug("Successfully updated Matched Subscription Aggregated Object list:" +
+                         "\nfor subsruptionId: " + subscriptionId +
+                         "\nwith Aggregated Object Id: " + aggrObjId +
+                         "\nwith matched Requirement Id: " + requirementId);
+            
+            return true;
+        }
+        return false;
     }
 
     public boolean checkIfAggrObjIdExistInSubscriptionAggrIdsMatchedList(String subscriptionId, int requirementId,
@@ -153,7 +161,7 @@ public class SubscriptionRepeatDbHandler {
             try {
                 JsonNode jNode = mapper.readTree(objArray.get(0));
                 if (jNode.get("subscriptionId").asText().trim().equals(subscriptionId)) {
-                    LOGGER.debug("SubscriptionId \"", subscriptionId,
+                    LOGGER.debug("SubscriptionId \"" + subscriptionId +
                             "\" , exist in document. Checking if AggrObjId has matched earlier.");
 
                     LOGGER.debug("Subscription requirementId: " + requirementId + " and Requirements content:\n"
@@ -161,10 +169,10 @@ public class SubscriptionRepeatDbHandler {
 
                     boolean triggered = checkRequirementIdTriggered(jNode, requirementId, aggrObjId);
 
-                    if (!triggered)
+                    if (!triggered) {
                         LOGGER.debug("RequirementId: " + requirementId + " and SubscriptionId: " + subscriptionId
                                 + "\nhas not matched any AggregatedObject.");
-
+                    }
                     return triggered;
                 }
             } catch (Exception e) {
@@ -189,8 +197,8 @@ public class SubscriptionRepeatDbHandler {
             return false;
         }
 
-        String idStr = listAggrObjIds.get(requirementId);
-        if (idStr.equals(aggrObjId)) {
+//        String idStr = listAggrObjIds.get(requirementId);
+        if (listAggrObjIds.contains(aggrObjId)) {
             LOGGER.debug("Subscription has matched aggrObjId already: " + aggrObjId);
             return true;
         }


### PR DESCRIPTION
This change solves the storing issues of multiple aggregated objects ids in different MongoDb document indexes and multiple of aggregated objects ids for same subscriptions requirements matched aggregated object ids list in RepeatHandler database collection.

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
