### PR TITLE
Fix restPostBodyMediaType to not be mandatory in a mail subcription

### DIFF
--- a/src/integrationtests/resources/features/ArtifactFlowIT.feature
+++ b/src/integrationtests/resources/features/ArtifactFlowIT.feature
@@ -31,7 +31,6 @@ Feature: Artifact flow Integrationtest
     # Setup subscription
     Given subscription object for "MAIL" with name "MailTestSubscription" is created
     When notification meta "some.cool.email@ericsson.com" is set in subscription
-    And rest post body media type is set to "crazy-pinguin" is set in subscription
     And paremeter form key "" and form value "to_string(@)" is added in subscription
     And condition "id=='aacc3c87-75e0-4b6d-88f5-b1a5d4e62b43'" at requirement index '0' is added in subscription
     Then subscription is uploaded

--- a/src/main/resources/schemas/subscription_schema.json
+++ b/src/main/resources/schemas/subscription_schema.json
@@ -66,5 +66,5 @@
              "type":"string"
           }
        },       
-       "required": ["notificationMeta", "notificationType","restPostBodyMediaType", "subscriptionName", "requirements"]
+       "required": ["notificationMeta", "notificationType", "subscriptionName", "requirements"]
  }


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->
### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
- restPostBodyMediaType was mandatory even with a mail subscription. Now it is only mandatory if you have a REST_POST subscription(That functionality was already implemented).
- Changed test to reflect this.
### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
Erik Edling erik.edling@ericsson.com