### PR TITLE
Added Rule File path property and other properties check and logs.

### DIFF
--- a/src/main/java/com/ericsson/ei/App.java
+++ b/src/main/java/com/ericsson/ei/App.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.Scope;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -31,11 +32,17 @@ import org.springframework.context.support.SimpleThreadScope;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import com.ericsson.ei.config.CheckEIConfigurations;
+import com.ericsson.ei.rules.RulesHandler;
+
 @SpringBootApplication
 @EnableAsync
 @EnableScheduling
 public class App extends SpringBootServletInitializer {
-
+    
+    @Autowired
+    private CheckEIConfigurations checkEIConfigurations;
+    
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
         return application.sources(App.class);

--- a/src/main/java/com/ericsson/ei/App.java
+++ b/src/main/java/com/ericsson/ei/App.java
@@ -28,6 +28,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.support.SimpleThreadScope;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -35,13 +36,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import com.ericsson.ei.config.CheckEIConfigurations;
 import com.ericsson.ei.rules.RulesHandler;
 
+
 @SpringBootApplication
 @EnableAsync
 @EnableScheduling
 public class App extends SpringBootServletInitializer {
-    
-    @Autowired
-    private CheckEIConfigurations checkEIConfigurations;
     
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {

--- a/src/main/java/com/ericsson/ei/config/CheckEIConfigurations.java
+++ b/src/main/java/com/ericsson/ei/config/CheckEIConfigurations.java
@@ -22,7 +22,7 @@ public class CheckEIConfigurations {
     Environment env;
     
     @PostConstruct
-    public void logCofiguration() {
+    public void logAndCheckConfiguration() {
         
         String rulePath = env.getProperty("rules.path");
         
@@ -86,8 +86,8 @@ public class CheckEIConfigurations {
         
         try {
             new RulesHandler().readRuleFileContent(rulePath);
-        } catch (IOException e) {
-            LOGGER.debug("Rules file can't be loaded/read. RuleFile path: " +  rulePath, e.getMessage(), e);
+        } catch (Exception e) {
+            LOGGER.debug("Rules file failed to be loaded/read. RuleFile path: " +  rulePath, e.getMessage());
         } finally {
             LOGGER.debug("Rules file path check performed successfully, Rule File: " + rulePath);
         }

--- a/src/main/java/com/ericsson/ei/config/CheckEIConfigurations.java
+++ b/src/main/java/com/ericsson/ei/config/CheckEIConfigurations.java
@@ -82,7 +82,7 @@ public class CheckEIConfigurations {
                 + "logging.level.root: " + env.getProperty("logging.level.root") + "\n"
                 + "logging.level.org.springframework.web: " + env.getProperty("logging.level.org.springframework.web") + "\n"
                 + "logging.level.com.ericsson.ei: " + env.getProperty("logging.level.com.ericsson.ei") + "\n"
-                + "\nThese properties is only some of the configuraitons, more configurations can have been provided.\n");
+                + "\nThese properties are only some of the configuraitons, more configurations could have been provided.\n");
         
         try {
             new RulesHandler().readRuleFileContent(rulePath);

--- a/src/main/java/com/ericsson/ei/config/CheckEIConfigurations.java
+++ b/src/main/java/com/ericsson/ei/config/CheckEIConfigurations.java
@@ -89,7 +89,7 @@ public class CheckEIConfigurations {
         } catch (IOException e) {
             LOGGER.debug("Rules file can't be loaded/read. RuleFile path: " +  rulePath, e.getMessage(), e);
         } finally {
-            LOGGER.debug("Rules file path check performed succesffully, Rule File: " + rulePath);
+            LOGGER.debug("Rules file path check performed successfully, Rule File: " + rulePath);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/config/CheckEIConfigurations.java
+++ b/src/main/java/com/ericsson/ei/config/CheckEIConfigurations.java
@@ -1,0 +1,95 @@
+package com.ericsson.ei.config;
+
+import java.io.IOException;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import com.ericsson.ei.rules.RulesHandler;
+
+
+@Component
+public class CheckEIConfigurations {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckEIConfigurations.class);
+    
+    @Autowired
+    Environment env;
+    
+    @PostConstruct
+    public void logCofiguration() {
+        
+        String rulePath = env.getProperty("rules.path");
+        
+        LOGGER.debug("EI Backend started with following configurations:\n"
+                + "server.port: " + env.getProperty("server.port") + "\n"
+                + "server.session-timeout: " + env.getProperty("server.session-timeout") + "\n"
+                + "rules.path: " + rulePath + "\n"
+                + "rabbitmq.host: " + env.getProperty("rabbitmq.host") + "\n"
+                + "rabbitmq.port: " + env.getProperty("rabbitmq.port") + "\n"
+                + "rabbitmq.user: " + env.getProperty("rabbitmq.user") + "\n"
+                + "rabbitmq.tlsVersion: " + env.getProperty("rabbitmq.tlsVersion") + "\n"
+                + "rabbitmq.exchange.name: " + env.getProperty("rabbitmq.exchange.name") + "\n"
+                + "rabbitmq.domainId: " + env.getProperty("rabbitmq.domainId") + "\n"
+                + "rabbitmq.componentName: " + env.getProperty("rabbitmq.componentName") + "\n"
+                + "rabbitmq.consumerName: " + env.getProperty("rabbitmq.consumerName") + "\n"
+                + "rabbitmq.queue.durable: " + env.getProperty("rabbitmq.queue.durable") + "\n"
+                + "rabbitmq.binding.key: " + env.getProperty("rabbitmq.binding.key") + "\n"
+                + "rabbitmq.waitlist.queue.suffix: " + env.getProperty("rabbitmq.waitlist.queue.suffix") + "\n"
+                + "mergeidmarker: " + env.getProperty("mergeidmarker") + "\n"
+                + "spring.data.mongodb.host: " + env.getProperty("spring.data.mongodb.host") + "\n"
+                + "spring.data.mongodb.port: " + env.getProperty("spring.data.mongodb.port") + "\n"
+                + "spring.data.mongodb.username: " + env.getProperty("spring.data.mongodb.username") + "\n"
+                + "spring.data.mongodb.database: " + env.getProperty("spring.data.mongodb.database") + "\n"
+                + "sessions.collection.name: " + env.getProperty("sessions.collection.name") + "\n"
+                + "search.query.prefix: " + env.getProperty("search.query.prefix") + "\n"
+                + "aggregated.object.name: " + env.getProperty("aggregated.object.name") + "\n"
+                + "aggregated.collection.name: " + env.getProperty("aggregated.collection.name") + "\n"
+                + "aggregated.collection.ttlValue: " + env.getProperty("aggregated.collection.ttlValue") + "\n"
+                + "event_object_map.collection.name: " + env.getProperty("event_object_map.collection.name") + "\n"
+                + "waitlist.collection.name: " + env.getProperty("waitlist.collection.name") + "\n"
+                + "waitlist.collection.ttlValue: " + env.getProperty("waitlist.collection.ttlValue") + "\n"
+                + "waitlist.initialDelayResend: " + env.getProperty("waitlist.initialDelayResend") + "\n"
+                + "waitlist.fixedRateResend: " + env.getProperty("waitlist.fixedRateResend") + "\n"
+                + "subscription.collection.name: " + env.getProperty("subscription.collection.name") + "\n"
+                + "subscription.collection.repeatFlagHandlerName: " + env.getProperty("subscription.collection.repeatFlagHandlerName") + "\n"
+                + "testaggregated.enabled: " + env.getProperty("testaggregated.enabled") + "\n"
+                + "threads.corePoolSize: " + env.getProperty("threads.corePoolSize") + "\n"
+                + "threads.queueCapacity: " + env.getProperty("threads.queueCapacity") + "\n"
+                + "threads.maxPoolSize: " + env.getProperty("threads.maxPoolSize") + "\n"
+                + "missedNotificationCollectionName: " + env.getProperty("missedNotificationCollectionName") + "\n"
+                + "missedNotificationDataBaseName: " + env.getProperty("missedNotificationDataBaseName") + "\n"
+                + "email.sender: " + env.getProperty("email.sender") + "\n"
+                + "email.subject: " + env.getProperty("email.subject") + "\n"
+                + "notification.failAttempt: " + env.getProperty("notification.failAttempt") + "\n"
+                + "notification.ttl.value: " + env.getProperty("notification.ttl.value") + "\n"
+                + "spring.mail.host: " + env.getProperty("spring.mail.host") + "\n"
+                + "spring.mail.port: " + env.getProperty("spring.mail.port") + "\n"
+                + "spring.mail.username: " + env.getProperty("spring.mail.username") + "\n"
+                + "spring.mail.properties.mail.smtp.auth: " + env.getProperty("spring.mail.properties.mail.smtp.auth") + "\n"
+                + "spring.mail.properties.mail.smtp.starttls.enable: " + env.getProperty("spring.mail.properties.mail.smtp.starttls.enable") + "\n"
+                + "er.url: " + env.getProperty("er.url") + "\n"
+                + "ldap.enabled: " + env.getProperty("ldap.enabled") + "\n"
+                + "ldap.url: " + env.getProperty("ldap.url") + "\n"
+                + "ldap.base.dn: " + env.getProperty("ldap.base.dn") + "\n"
+                + "ldap.username: " + env.getProperty("ldap.username") + "\n"
+                + "ldap.user.filter: " + env.getProperty("ldap.user.filter") + "\n"
+                + "logging.level.root: " + env.getProperty("logging.level.root") + "\n"
+                + "logging.level.org.springframework.web: " + env.getProperty("logging.level.org.springframework.web") + "\n"
+                + "logging.level.com.ericsson.ei: " + env.getProperty("logging.level.com.ericsson.ei") + "\n"
+                + "\nThese properties is only some of the configuraitons, more configurations can have been provided.\n");
+        
+        try {
+            new RulesHandler().readRuleFileContent(rulePath);
+        } catch (IOException e) {
+            LOGGER.debug("Rules file can't be loaded/read. RuleFile path: " +  rulePath, e.getMessage(), e);
+        } finally {
+            LOGGER.debug("Rules file path check performed succesffully, Rule File: " + rulePath);
+        }
+    }
+}

--- a/src/main/java/com/ericsson/ei/rules/RulesHandler.java
+++ b/src/main/java/com/ericsson/ei/rules/RulesHandler.java
@@ -57,20 +57,27 @@ public class RulesHandler {
         ObjectMapper objectmapper = new ObjectMapper();
         parsedJson = objectmapper.readTree(jsonContent);
     }
+    
+    public String readRuleFileContent(String ruleFilePath) throws IOException {
+        String ruleJsonFileContent;
+        InputStream in = this.getClass().getResourceAsStream(ruleFilePath);
+        if(in == null) {
+            ruleJsonFileContent = FileUtils.readFileToString(new File(ruleFilePath), Charset.defaultCharset());
+        } else {
+            ruleJsonFileContent = getContent(in);
+        }
+        return ruleJsonFileContent;
+    }
 
     @PostConstruct public void init() {
+
         if (parsedJson == null) {
             try {
-                InputStream in = this.getClass().getResourceAsStream(jsonFilePath);
-                if(in == null) {
-                    jsonFileContent = FileUtils.readFileToString(new File(jsonFilePath), Charset.defaultCharset());
-                } else {
-                    jsonFileContent = getContent(in);
-                }
+                jsonFileContent = readRuleFileContent(jsonFilePath);
                 ObjectMapper objectmapper = new ObjectMapper();
                 parsedJson = objectmapper.readTree(jsonFileContent);
             } catch (Exception e) {
-                LOGGER.error(e.getMessage(), e);
+                LOGGER.error("RulesHandler Init: Failed to read Rules file: " + jsonFilePath, e.getMessage(), e);
             }
         }
     }
@@ -82,7 +89,7 @@ public class RulesHandler {
             ObjectMapper objectmapper = new ObjectMapper();
             parsedJson = objectmapper.readTree(jsonFileContent);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error("Failed to read Rules file: " + jsonFilePath, e.getMessage(), e);
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ rules.path: /ArtifactRules.json
 # it is possible to only activate logging for a certain package under 
 # these top packages
 logging.level.root: OFF
-logging.level.org.springframework.web: DEBUG
+logging.level.org.springframework.web: ERROR
 logging.level.com.ericsson.ei: DEBUG
 
 # Details for connection to RabbitMQ

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.application.name=eiffel-intelligence
 build.version=
 
 # port where Eiffel Intelligence will run
-server.port: 8090
+server.port: 8070
 
 # path to files with rules for aggregating objects
 rules.path: /ArtifactRules.json
@@ -16,8 +16,8 @@ rules.path: /ArtifactRules.json
 # it is possible to only activate logging for a certain package under 
 # these top packages
 logging.level.root: OFF
-logging.level.org.springframework.web: ERROR
-logging.level.com.ericsson.ei: ERROR
+logging.level.org.springframework.web: DEBUG
+logging.level.com.ericsson.ei: DEBUG
 
 # Details for connection to RabbitMQ
 rabbitmq.host: localhost
@@ -26,7 +26,7 @@ rabbitmq.user: myuser
 rabbitmq.password: myuser
 # Valid TLS versions: 'TLSv1.2', 'TLSv1.1', 'TLSv1', 'TLS', 'SSLv3', 'SSLv2', 'SSL'
 rabbitmq.tlsVersion:
-rabbitmq.exchange.name: ei-exchange
+rabbitmq.exchange.name: ei-poc-4
 rabbitmq.domainId: ei-domain
 rabbitmq.componentName: eiffel-intelligence
 rabbitmq.consumerName: messageConsumer
@@ -45,7 +45,9 @@ spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.embedd
 # Details for connection to mongoDB
 spring.data.mongodb.host: localhost
 spring.data.mongodb.port: 27017
-spring.data.mongodb.database: eiffel_intelligence
+#spring.data.mongodb.username:
+#spring.data.mongodb.password:
+spring.data.mongodb.database: eiffel2_intelligence-artifact
 # we cannot have empty username and password property here
 # if these properties are empty, remove or comment them
 #spring.data.mongodb.username:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.application.name=eiffel-intelligence
 build.version=
 
 # port where Eiffel Intelligence will run
-server.port: 8070
+server.port: 8090
 
 # path to files with rules for aggregating objects
 rules.path: /ArtifactRules.json
@@ -26,7 +26,7 @@ rabbitmq.user: myuser
 rabbitmq.password: myuser
 # Valid TLS versions: 'TLSv1.2', 'TLSv1.1', 'TLSv1', 'TLS', 'SSLv3', 'SSLv2', 'SSL'
 rabbitmq.tlsVersion:
-rabbitmq.exchange.name: ei-poc-4
+rabbitmq.exchange.name: ei-exchange
 rabbitmq.domainId: ei-domain
 rabbitmq.componentName: eiffel-intelligence
 rabbitmq.consumerName: messageConsumer
@@ -47,7 +47,7 @@ spring.data.mongodb.host: localhost
 spring.data.mongodb.port: 27017
 #spring.data.mongodb.username:
 #spring.data.mongodb.password:
-spring.data.mongodb.database: eiffel2_intelligence-artifact
+spring.data.mongodb.database: eiffel_intelligence
 # we cannot have empty username and password property here
 # if these properties are empty, remove or comment them
 #spring.data.mongodb.username:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,7 +17,7 @@ rules.path: /ArtifactRules.json
 # these top packages
 logging.level.root: OFF
 logging.level.org.springframework.web: ERROR
-logging.level.com.ericsson.ei: DEBUG
+logging.level.com.ericsson.ei: ERROR
 
 # Details for connection to RabbitMQ
 rabbitmq.host: localhost


### PR DESCRIPTION
Today it is really hard to see what rule file that is being used or if EI fails to load Rules file.

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
Update EI so Rule path is logged and improve logging when Rule path fails to load.
Update so other properties is logged, so its visible which configuration that is being used in the logs.
Password properties is not logged nor printed in console/logs.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
