### PR TITLE
Fix null point exception deleteing subscription without ldapUserName

### DIFF
--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -186,10 +186,9 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                 LOG.error("Error: " + e.getMessage());
                 errorMap.put(subscriptionName, INVALID_USER);
             } catch (Exception e) {
-                String errorMessage = "Failed to delete subscriptions. Exception: " + e.getClass().toString()
-                        + ". Error message:\n" + e.getMessage();
+                String errorMessage = "Failed to delete subscriptions. Error message:\n" + e.getMessage();
                 LOG.error(errorMessage, e);
-                errorMap.put(subscriptionName, e.getMessage());
+                errorMap.put(subscriptionName, e.getClass().toString() + " : " + e.getMessage());
             }
         });
         return getResponse();

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -186,7 +186,8 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                 LOG.error("Error: " + e.getMessage());
                 errorMap.put(subscriptionName, INVALID_USER);
             } catch (Exception e) {
-                String errorMessage = "Failed to delete subscriptions. Error message:\n" + e.getMessage();
+                String errorMessage = "Failed to delete subscriptions. Exception: " + e.getClass().toString()
+                        + ". Error message:\n" + e.getMessage();
                 LOG.error(errorMessage, e);
                 errorMap.put(subscriptionName, e.getMessage());
             }

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -65,8 +65,6 @@ public class SubscriptionControllerImpl implements SubscriptionController {
     @Autowired
     private ISubscriptionService subscriptionService;
 
-    private SubscriptionValidator subscriptionValidator = new SubscriptionValidator();
-
     private Map<String, String> errorMap;
 
     @Override
@@ -81,7 +79,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             String subscriptionName = subscription.getSubscriptionName();
             try {
                 LOG.debug("Subscription creation has been started: " + subscriptionName);
-                subscriptionValidator.validateSubscription(subscription);
+                SubscriptionValidator.validateSubscription(subscription);
 
                 if (!subscriptionService.doSubscriptionExist(subscriptionName)) {
                     subscription.setLdapUserName(user);
@@ -146,8 +144,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             String subscriptionName = subscription.getSubscriptionName();
             LOG.debug("Subscription updating has been started: " + subscriptionName);
             try {
-                subscriptionValidator.validateSubscription(subscription);
-
+                SubscriptionValidator.validateSubscription(subscription);
                 if (subscriptionService.doSubscriptionExist(subscriptionName)) {
                     subscription.setLdapUserName(user);
                     subscription.setCreated((float) Instant.now().toEpochMilli());
@@ -188,6 +185,10 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             } catch (AccessException e) {
                 LOG.error("Error: " + e.getMessage());
                 errorMap.put(subscriptionName, INVALID_USER);
+            } catch (Exception e) {
+                String errorMessage = "Failed to delete subscriptions. Error message:\n" + e.getMessage();
+                LOG.error(errorMessage, e);
+                errorMap.put(subscriptionName, e.getMessage());
             }
         });
         return getResponse();

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -83,7 +83,7 @@ public class SubscriptionService implements ISubscriptionService {
 
         ArrayList<String> list = subscriptionRepository.getSubscription(query);
         ObjectMapper mapper = new ObjectMapper();
-        if (list.isEmpty()) {
+        if (list == null || list.isEmpty()) {
             throw new SubscriptionNotFoundException("No record found for the Subscription Name:" + subscriptionName);
         }
         for (String input : list) {
@@ -163,7 +163,7 @@ public class SubscriptionService implements ISubscriptionService {
         ArrayList<String> list = subscriptionRepository.getSubscription(query);
         List<Subscription> subscriptions = new ArrayList<>();
         ObjectMapper mapper = new ObjectMapper();
-        if (list.isEmpty()) {
+        if (list == null || list.isEmpty()) {
             throw new SubscriptionNotFoundException("No Subscriptions found");
         }
         for (String input : list) {
@@ -217,7 +217,9 @@ public class SubscriptionService implements ISubscriptionService {
     private boolean doSubscriptionOwnerExist(String subscriptionName) {
         boolean ownerExist = false;
         try {
-            if (!getSubscription(subscriptionName).getLdapUserName().isEmpty()) {
+            Subscription subscription = getSubscription(subscriptionName);
+            String getLdapUserName = subscription.getLdapUserName();
+            if (getLdapUserName != null && getLdapUserName.isEmpty()) {
                 ownerExist = true;
             }
         } catch (SubscriptionNotFoundException e) {

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -219,7 +219,7 @@ public class SubscriptionService implements ISubscriptionService {
         try {
             Subscription subscription = getSubscription(subscriptionName);
             String getLdapUserName = subscription.getLdapUserName();
-            if (getLdapUserName != null && getLdapUserName.isEmpty()) {
+            if (getLdapUserName != null && !getLdapUserName.isEmpty()) {
                 ownerExist = true;
             }
         } catch (SubscriptionNotFoundException e) {

--- a/src/main/java/com/ericsson/ei/subscription/SubscriptionValidator.java
+++ b/src/main/java/com/ericsson/ei/subscription/SubscriptionValidator.java
@@ -44,9 +44,14 @@ public class SubscriptionValidator {
     private static final String SCHEMA_FILE_PATH = "/schemas/subscription_schema.json";
 
     /**
-     * Validation of parameters values in subscriptions objects. Throws
-     * SubscriptionValidationException if validation of a parameter fails due to
-     * wrong format of parameter.
+     * The private constructor forces all implementations to use the functions as static methods.
+     */
+    private SubscriptionValidator() {
+    }
+
+    /**
+     * Validation of parameters values in subscriptions objects. Throws SubscriptionValidationException
+     * if validation of a parameter fails due to wrong format of parameter.
      *
      * @param subscription
      */
@@ -65,9 +70,8 @@ public class SubscriptionValidator {
     }
 
     /**
-     * Validation of subscriptionName parameter Throws
-     * SubscriptionValidationException if validation of the parameter fails due
-     * to wrong format of parameter.
+     * Validation of subscriptionName parameter Throws SubscriptionValidationException if validation of
+     * the parameter fails due to wrong format of parameter.
      *
      * @param subscriptionName
      */
@@ -82,8 +86,8 @@ public class SubscriptionValidator {
 
     /**
      * Validation of NotificationMessageKeyValues parameters (key/values) Throws
-     * SubscriptionValidationException if validation of the parameter fails due
-     * to wrong format of parameter.
+     * SubscriptionValidationException if validation of the parameter fails due to wrong format of
+     * parameter.
      *
      * @param notificationMessage
      * @param restPostBodyMediaType
@@ -120,9 +124,8 @@ public class SubscriptionValidator {
     }
 
     /**
-     * Validation of notificationMeta parameter Throws
-     * SubscriptionValidationException if validation of the parameter fails due
-     * to wrong format of parameter.
+     * Validation of notificationMeta parameter Throws SubscriptionValidationException if validation of
+     * the parameter fails due to wrong format of parameter.
      *
      * @param notificationMeta
      * @param notificationType
@@ -137,15 +140,14 @@ public class SubscriptionValidator {
         if (Pattern.matches(regexMail, notificationType)) {
             String[] addresses = notificationMeta.split(",");
             for (String address : addresses) {
-                    validateEmail(address.trim());
+                validateEmail(address.trim());
             }
         }
     }
 
     /**
-     * Validation of notificationType parameter Throws
-     * SubscriptionValidationException if validation of the parameter fails due
-     * to wrong format of parameter.
+     * Validation of notificationType parameter Throws SubscriptionValidationException if validation of
+     * the parameter fails due to wrong format of parameter.
      *
      * @param notificationType
      */
@@ -172,8 +174,8 @@ public class SubscriptionValidator {
     }
 
     /**
-     * Validation of email address Throws SubscriptionValidationException if
-     * validation of the parameter fails due to wrong format of parameter.
+     * Validation of email address Throws SubscriptionValidationException if validation of the parameter
+     * fails due to wrong format of parameter.
      *
      * @param email
      */

--- a/src/test/java/com/ericsson/ei/subscription/SubscriptionValidatorTest.java
+++ b/src/test/java/com/ericsson/ei/subscription/SubscriptionValidatorTest.java
@@ -35,13 +35,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @PowerMockRunnerDelegate(SpringJUnit4ClassRunner.class)
 public class SubscriptionValidatorTest {
 
-    private SubscriptionValidator subscriptionValidator;
     private Subscription subscriptionValid;
     private Subscription subscriptionInvalid;
 
     public SubscriptionValidatorTest() {
-        subscriptionValidator = new SubscriptionValidator();
-
         // subscriptionValidator -------------------------
         subscriptionValid = new Subscription();
 
@@ -95,7 +92,7 @@ public class SubscriptionValidatorTest {
     public void validateSubscriptionNameValidNameTest() throws Exception {
         String subscriptionName = "Kalle1";
         try {
-            invokeMethod(subscriptionValidator, "validateSubscriptionName", subscriptionName);
+            invokeMethod(SubscriptionValidator.class, "validateSubscriptionName", subscriptionName);
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -106,7 +103,7 @@ public class SubscriptionValidatorTest {
     public void validateSubscriptionNameValidNameTest2() throws Exception {
         String subscriptionName = "Kalle_1";
         try {
-            invokeMethod(subscriptionValidator, "validateSubscriptionName", subscriptionName);
+            invokeMethod(SubscriptionValidator.class, "validateSubscriptionName", subscriptionName);
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -117,7 +114,7 @@ public class SubscriptionValidatorTest {
     public void validateSubscriptionNameInvalidNameTest() throws Exception {
         String subscriptionName = "Kal--l[[e1";
         try {
-            invokeMethod(subscriptionValidator, "validateSubscriptionName", subscriptionName);
+            invokeMethod(SubscriptionValidator.class, "validateSubscriptionName", subscriptionName);
         } catch (SubscriptionValidationException e) {
             return;
         }
@@ -128,7 +125,7 @@ public class SubscriptionValidatorTest {
     public void validateSubscriptionNameInvalidName2Test() throws Exception {
         String subscriptionName = "@Kal$le´1";
         try {
-            invokeMethod(subscriptionValidator, "validateSubscriptionName", subscriptionName);
+            invokeMethod(SubscriptionValidator.class, "validateSubscriptionName", subscriptionName);
         } catch (SubscriptionValidationException e) {
             return;
         }
@@ -143,7 +140,7 @@ public class SubscriptionValidatorTest {
         notificationMessageKeyValue.setFormvalue("@");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), "");
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
@@ -160,7 +157,7 @@ public class SubscriptionValidatorTest {
                 "{parameter: [{ name: 'jsonparams', value : to_string(@) }, { name: 'runpipeline', value : 'mybuildstep' }]}");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), MediaType.APPLICATION_JSON.toString());
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
@@ -177,7 +174,7 @@ public class SubscriptionValidatorTest {
                 "{parameter: [{ name: 'jsonparams', value : to_string(@) }, { name: 'runpipeline', value : 'mybuildstep' }]}");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), MediaType.APPLICATION_FORM_URLENCODED.toString());
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
@@ -199,7 +196,7 @@ public class SubscriptionValidatorTest {
                 "{parameter2: [{ name: 'jsonparams', value : to_string(@) }, { name: 'runpipeline', value : 'mybuildstep' }]}");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue2);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), MediaType.APPLICATION_FORM_URLENCODED.toString());
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
@@ -215,7 +212,7 @@ public class SubscriptionValidatorTest {
         notificationMessageKeyValue.setFormvalue("kalle.kalle@domain.com");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), "");
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), true);
@@ -233,7 +230,7 @@ public class SubscriptionValidatorTest {
                 "{parameter: [{ name: 'jsonparams', value : to_string(@) }, { name: 'runpipeline', value : 'mybuildstep' }]}");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), MediaType.APPLICATION_JSON.toString());
         } catch (SubscriptionValidationException e) {
             return;
@@ -250,7 +247,7 @@ public class SubscriptionValidatorTest {
                 "{parameter: [{ name: 'jsonparams', value : to_string(@) }, { name: 'runpipeline', value : 'mybuildstep' }]}");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), MediaType.APPLICATION_FORM_URLENCODED.toString());
         } catch (SubscriptionValidationException e) {
             return;
@@ -272,7 +269,7 @@ public class SubscriptionValidatorTest {
                 "{parameter2: [{ name: 'jsonparams', value : to_string(@) }, { name: 'runpipeline', value : 'mybuildstep' }]}");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue2);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), MediaType.APPLICATION_FORM_URLENCODED.toString());
         } catch (SubscriptionValidationException e) {
             return;
@@ -293,7 +290,7 @@ public class SubscriptionValidatorTest {
                 "{parameter2: [{ name: 'jsonparams', value : to_string(@) }, { name: 'runpipeline', value : 'mybuildstep' }]}");
         subscription.getNotificationMessageKeyValues().add(notificationMessageKeyValue2);
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMessageKeyValues",
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMessageKeyValues",
                     subscription.getNotificationMessageKeyValues(), MediaType.APPLICATION_FORM_URLENCODED.toString());
         } catch (SubscriptionValidationException e) {
             return;
@@ -304,7 +301,7 @@ public class SubscriptionValidatorTest {
     @Test
     public void validateRestPostMediaTypeValidMessageTest() throws Exception {
         try {
-            invokeMethod(subscriptionValidator, "RestPostMediaType", MediaType.APPLICATION_FORM_URLENCODED.toString());
+            invokeMethod(SubscriptionValidator.class, "RestPostMediaType", MediaType.APPLICATION_FORM_URLENCODED.toString());
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -314,7 +311,7 @@ public class SubscriptionValidatorTest {
     @Test
     public void validateRestPostMediaTypeValidMessage2Test() throws Exception {
         try {
-            invokeMethod(subscriptionValidator, "RestPostMediaType", MediaType.APPLICATION_JSON.toString());
+            invokeMethod(SubscriptionValidator.class, "RestPostMediaType", MediaType.APPLICATION_JSON.toString());
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -324,7 +321,7 @@ public class SubscriptionValidatorTest {
     @Test
     public void validateRestPostMediaTypeInvalidMessageTest() throws Exception {
         try {
-            invokeMethod(subscriptionValidator, "RestPostMediaType",
+            invokeMethod(SubscriptionValidator.class, "RestPostMediaType",
                     MediaType.APPLICATION_OCTET_STREAM_VALUE.toString());
         } catch (SubscriptionValidationException e) {
             return;
@@ -335,7 +332,7 @@ public class SubscriptionValidatorTest {
     @Test
     public void validateRestPostMediaTypeInvalidMessage2Test() throws Exception {
         try {
-            invokeMethod(subscriptionValidator, "RestPostMediaType", "");
+            invokeMethod(SubscriptionValidator.class, "RestPostMediaType", "");
         } catch (SubscriptionValidationException e) {
             return;
         }
@@ -352,7 +349,7 @@ public class SubscriptionValidatorTest {
         String notificationMeta = "kalle.kalle@domain.com";
         String notificationType = "MAIL";
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMeta", notificationMeta, notificationType);
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMeta", notificationMeta, notificationType);
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -364,7 +361,7 @@ public class SubscriptionValidatorTest {
         String notificationMeta = "kalle.kall  e@domain.com";
         String notificationType = "MAIL";
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMeta", notificationMeta, notificationType);
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMeta", notificationMeta, notificationType);
         } catch (SubscriptionValidationException e) {
             return;
         }
@@ -376,7 +373,7 @@ public class SubscriptionValidatorTest {
         String notificationMeta = "";
         String notificationType = "REST_POST";
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMeta", notificationMeta, notificationType);
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMeta", notificationMeta, notificationType);
         } catch (SubscriptionValidationException e) {
             return;
         }
@@ -388,7 +385,7 @@ public class SubscriptionValidatorTest {
         String notificationMeta = "http://127.0.0.1:3000/ei/test_subscription_rest?json=links[?type=='SUBJECT'].target | [0]";
         String notificationType = "REST_POST";
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationMeta", notificationMeta, notificationType);
+            invokeMethod(SubscriptionValidator.class, "validateNotificationMeta", notificationMeta, notificationType);
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -402,7 +399,7 @@ public class SubscriptionValidatorTest {
     public void validateNotificationTypeValidTypeMAILTest() throws Exception {
         String notificationType = "MAIL";
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationType", notificationType);
+            invokeMethod(SubscriptionValidator.class, "validateNotificationType", notificationType);
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -413,7 +410,7 @@ public class SubscriptionValidatorTest {
     public void validateNotificationTypeValidTypeRESTPOSTTest() throws Exception {
         String notificationType = "REST_POST";
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationType", notificationType);
+            invokeMethod(SubscriptionValidator.class, "validateNotificationType", notificationType);
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -424,7 +421,7 @@ public class SubscriptionValidatorTest {
     public void validateNotificationTypeInvalidTypeTest() throws Exception {
         String notificationType = "INVALID_TYPE";
         try {
-            invokeMethod(subscriptionValidator, "validateNotificationType", notificationType);
+            invokeMethod(SubscriptionValidator.class, "validateNotificationType", notificationType);
         } catch (SubscriptionValidationException e) {
             return;
         }
@@ -441,7 +438,7 @@ public class SubscriptionValidatorTest {
     @Test
     public void validateFullSubscriptionWithValidSubscriptionParameters() {
         try {
-            subscriptionValidator.validateSubscription(subscriptionValid);
+            SubscriptionValidator.validateSubscription(subscriptionValid);
         } catch (SubscriptionValidationException e) {
             assertTrue(e.getMessage(), false);
             return;
@@ -452,7 +449,7 @@ public class SubscriptionValidatorTest {
     @Test
     public void validateFullSubscriptionWithInvalidSubscriptionParameters() {
         try {
-            subscriptionValidator.validateSubscription(subscriptionInvalid);
+            SubscriptionValidator.validateSubscription(subscriptionInvalid);
         } catch (SubscriptionValidationException e) {
             return;
         }
@@ -463,7 +460,7 @@ public class SubscriptionValidatorTest {
     public void validateSubscriptionWithSchemaTest() throws Exception {
 
         try {
-            invokeMethod(subscriptionValidator, "validateWithSchema", subscriptionValid);
+            invokeMethod(SubscriptionValidator.class, "validateWithSchema", subscriptionValid);
         } catch (SubscriptionValidationException e) {
             assertTrue(false);
         }
@@ -477,7 +474,7 @@ public class SubscriptionValidatorTest {
 
         subscriptionValidCopy.setSubscriptionName(null);
         try {
-            invokeMethod(subscriptionValidator, "validateWithSchema", subscriptionValidCopy);
+            invokeMethod(SubscriptionValidator.class, "validateWithSchema", subscriptionValidCopy);
         } catch (SubscriptionValidationException e) {
             return;
         }


### PR DESCRIPTION
- A null value when trying to fetch ldapUserName will no longer cause problems
- Implemented test to ensure that null value is handled correctly
- Error handling when failure to delete a subscription is added and should be responded to the user.
- Minor improvement in SubscriptionValidator class that forces the static methods to be called as static methods.


### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
