### PR TITLE
Standardize error message handling

### DIFF
--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/authentication/AuthenticationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/authentication/AuthenticationSteps.java
@@ -112,13 +112,14 @@ public class AuthenticationSteps extends FunctionalTestBase {
         httpRequest.setHost(hostName).setPort(applicationPort).setEndpoint("/subscriptions/" + SUBSCRIPTION_NAME);
 
         response = httpRequest.performRequest();
-        GetSubscriptionResponse subscription = new ObjectMapper().readValue(response.getBody().toString(),
-                GetSubscriptionResponse.class);
         if (!check.isEmpty()) {
+            JSONObject jsonResponse = new JSONObject(response.getBody().toString());
+            String errorMessage = jsonResponse.getString("message");
             assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-            assertEquals(true, subscription.getFoundSubscriptions().isEmpty());
-            assertEquals(SUBSCRIPTION_NAME, subscription.getNotFoundSubscriptions().get(0));
+            assertEquals(true, errorMessage.contains(SUBSCRIPTION_NAME));
         } else {
+            GetSubscriptionResponse subscription = new ObjectMapper().readValue(response.getBody().toString(),
+                    GetSubscriptionResponse.class);
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertEquals(true, subscription.getNotFoundSubscriptions().isEmpty());
             assertEquals(SUBSCRIPTION_NAME, subscription.getFoundSubscriptions().get(0).getSubscriptionName());

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/bulk/SubscriptionBulkSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/bulk/SubscriptionBulkSteps.java
@@ -116,6 +116,13 @@ public class SubscriptionBulkSteps extends FunctionalTestBase {
         assertEquals(subscriptionName, jsonResponse.getString("subscription"));
     }
 
+    @Then("^get in response content subscription \"([^\"]*)\" expecting an error$")
+    public void get_in_response_content_subscription_and_reason_with_error(String subscriptionName) throws Throwable {
+        JSONObject jsonResponse = new JSONObject(response.getBody().toString());
+        String errorMessage = jsonResponse.getString("message");
+        assertEquals(true, errorMessage.contains(subscriptionName));
+    }
+
     @Then("^number of retrieved subscriptions using REST API \"([^\"]*)\" is (\\d+)$")
     public void number_of_retrieved_subscriptions_using_REST_API_is(
             String endpoint, int subscriptionsNumber) throws Throwable {

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/crud/SubscriptionCRUDSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/crud/SubscriptionCRUDSteps.java
@@ -120,18 +120,17 @@ public class SubscriptionCRUDSteps extends FunctionalTestBase {
         response = httpRequest.performRequest();
     }
 
-    @Then("^My GET request with subscription name \"([^\"]*)\" at REST API \"([^\"]*)\" returns an empty String$")
+    @Then("^My GET request with subscription name \"([^\"]*)\" at REST API \"([^\"]*)\" returns an error message$")
     public void my_GET_request_with_subscription_name_at_REST_API_returns_empty_String(String name, String endPoint)
             throws Throwable {
         httpRequest = new HttpRequest(HttpMethod.GET);
         httpRequest.setHost(hostName).setPort(applicationPort).setEndpoint(endPoint + name)
                 .addHeader("Accept", "application/json");
         response = httpRequest.performRequest();
-        JsonNode node = eventManager.getJSONFromString(response.getBody());
-        int size = node.get("foundSubscriptions").size();
-        String notFound = node.get("notFoundSubscriptions").get(0).asText();
-        assertEquals("Subscription was found, should be empty",0, size);
-        assertEquals(name, notFound);
+        JSONObject jsonResponse = new JSONObject(response.getBody().toString());
+        String errorMessage = jsonResponse.getString("message");
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(true, errorMessage.contains(name));
     }
     // Scenario:4 ends ==================================================================
 }

--- a/src/functionaltests/resources/features/subscriptionBulk.feature
+++ b/src/functionaltests/resources/features/subscriptionBulk.feature
@@ -22,7 +22,7 @@ Feature: Test Subscription Bulk Operations
      Given file with subscriptions "/subscriptions_multiple_wrong.json"
      When make a POST request with list of subscriptions to the subscription REST API "/subscriptions"
      Then get response code of 400
-     And get in response content subscription "Subscription_Test_2"
+     And get in response content subscription "Subscription_Test_2" expecting an error
      And number of retrieved subscriptions using REST API "/subscriptions" is 5
 
   @DeleteSubscriptions
@@ -44,12 +44,12 @@ Feature: Test Subscription Bulk Operations
     Given file with subscriptions "/subscriptions_multiple_wrong_updated.json"
     When make a PUT request with list of subscriptions to the subscription REST API "/subscriptions"
     Then get response code of 400
-    And get in response content subscription "Subscription_Test_Not_Found"
+    And get in response content subscription "Subscription_Test_Not_Found" expecting an error
     And number of retrieved subscriptions using REST API "/subscriptions" is 3
 
   @DeleteSubscriptionsNonExisting
   Scenario: Delete multiple subscriptions using REST API, one subscription does not exist
     When make a DELETE request with list of subscriptions names "Subscription_Test_1,Subscription_Test_2,Subscription_Test_Not_Found,Subscription_Test_3" to the subscription REST API "/subscriptions"
     Then get response code of 400
-    And get in response content subscription "Subscription_Test_Not_Found"
+    And get in response content subscription "Subscription_Test_Not_Found" expecting an error
     And number of retrieved subscriptions using REST API "/subscriptions" is 0

--- a/src/functionaltests/resources/features/subscriptionCRUD.feature
+++ b/src/functionaltests/resources/features/subscriptionCRUD.feature
@@ -33,4 +33,4 @@ Feature: Test Subscription CRUD
     Given The REST API "/subscriptions" is up and running
     When  I make a DELETE request with subscription name "Subscription_Test" to the subscription REST API "/subscriptions/"
     Then  I get response code of 200
-    And   My GET request with subscription name "Subscription_Test" at REST API "/subscriptions/" returns an empty String
+    And   My GET request with subscription name "Subscription_Test" at REST API "/subscriptions/" returns an error message

--- a/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
@@ -26,6 +26,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+import com.ericsson.ei.utils.ResponseMessage;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
@@ -52,7 +54,7 @@ public class AuthControllerImpl implements AuthController {
         } catch (Exception e) {
             String errorMessage = "Failed to check if security is enabled. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -66,7 +68,7 @@ public class AuthControllerImpl implements AuthController {
         } catch (Exception e) {
             String errorMessage = "Failed to log in user. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -79,7 +81,7 @@ public class AuthControllerImpl implements AuthController {
         } catch (Exception e) {
             String errorMessage = "Failed to check backend status. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
@@ -54,7 +54,8 @@ public class AuthControllerImpl implements AuthController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to check if security is enabled.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -68,7 +69,8 @@ public class AuthControllerImpl implements AuthController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to log in user.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -81,7 +83,8 @@ public class AuthControllerImpl implements AuthController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to check backend status.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
@@ -16,7 +16,6 @@
 */
 package com.ericsson.ei.controller;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
@@ -54,7 +54,7 @@ public class AuthControllerImpl implements AuthController {
             return new ResponseEntity<>(new JSONObject().put("security", ldapEnabled).toString(), HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to check if security is enabled.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -68,7 +68,7 @@ public class AuthControllerImpl implements AuthController {
             return new ResponseEntity<>(new JSONObject().put("user", currentUser).toString(), HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to log in user.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -81,7 +81,7 @@ public class AuthControllerImpl implements AuthController {
             return new ResponseEntity<>("Backend server is up and running", HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to check backend status.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/AuthControllerImpl.java
@@ -16,6 +16,7 @@
 */
 package com.ericsson.ei.controller;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,8 +53,8 @@ public class AuthControllerImpl implements AuthController {
         try {
             return new ResponseEntity<>(new JSONObject().put("security", ldapEnabled).toString(), HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = "Failed to check if security is enabled. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to check if security is enabled.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -66,8 +67,8 @@ public class AuthControllerImpl implements AuthController {
             String currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
             return new ResponseEntity<>(new JSONObject().put("user", currentUser).toString(), HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = "Failed to log in user. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to log in user.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -79,8 +80,8 @@ public class AuthControllerImpl implements AuthController {
         try {
             return new ResponseEntity<>("Backend server is up and running", HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = "Failed to check backend status. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to check backend status.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
@@ -50,7 +50,7 @@ public class DownloadControllerImpl implements DownloadController {
             return new ResponseEntity<>(response.toString(), HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to get information about download endpoints.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -59,13 +59,11 @@ public class DownloadControllerImpl implements DownloadController {
     public ResponseEntity<?> getDownloadSubscriptionsTemplate() {
         try {
             InputStream is = getClass().getResourceAsStream("/templates/subscriptionsTemplate.json");
+
             return new ResponseEntity<>(IOUtils.toByteArray(is), HttpStatus.OK);
-        } catch (IOException e) {
-            LOGGER.error(e.getMessage(), ExceptionUtils.getStackTrace(e));
-            return new ResponseEntity<>("Subscriptions template file is not found", HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to download subscriptions template file.";
-            LOGGER.error(e.getMessage(), ExceptionUtils.getStackTrace(e));
+            LOGGER.error(e.getMessage(), e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -74,13 +72,15 @@ public class DownloadControllerImpl implements DownloadController {
     public ResponseEntity<?> getDownloadRulesTemplate() {
         try {
             InputStream is = getClass().getResourceAsStream("/templates/rulesTemplate.json");
+            if (is == null) {
+                String errorMessage = "Rules template file is not found.";
+                LOGGER.error(errorMessage);
+                return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.NOT_FOUND);
+            }
             return new ResponseEntity<>(IOUtils.toByteArray(is), HttpStatus.OK);
-        } catch (IOException e) {
-            LOGGER.error(e.getMessage(), ExceptionUtils.getStackTrace(e));
-            return new ResponseEntity<>("Rules template file is not found", HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to download rules template file.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -89,13 +89,15 @@ public class DownloadControllerImpl implements DownloadController {
     public ResponseEntity<?> getDownloadEventsTemplate() {
         try {
             InputStream is = getClass().getResourceAsStream("/templates/eventsTemplate.json");
+            if (is == null) {
+                String errorMessage = "Events template file is not found.";
+                LOGGER.error(errorMessage);
+                return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.NOT_FOUND);
+            }
             return new ResponseEntity<>(IOUtils.toByteArray(is), HttpStatus.OK);
-        } catch (IOException e) {
-            LOGGER.error(e.getMessage(), ExceptionUtils.getStackTrace(e));
-            return new ResponseEntity<>("Events template file is not found", HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to download events template file.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
@@ -49,7 +49,8 @@ public class DownloadControllerImpl implements DownloadController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to get information about download endpoints.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -66,7 +67,8 @@ public class DownloadControllerImpl implements DownloadController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to download subscriptions template file.";
             LOGGER.error(e.getMessage(), e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -83,7 +85,8 @@ public class DownloadControllerImpl implements DownloadController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to download rules template file.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -100,7 +103,8 @@ public class DownloadControllerImpl implements DownloadController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to download events template file.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,8 +49,8 @@ public class DownloadControllerImpl implements DownloadController {
             response.put("events", "/download/eventsTemplate");
             return new ResponseEntity<>(response.toString(), HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = "Failed to get information about download endpoints. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to get information about download endpoints.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -60,11 +61,11 @@ public class DownloadControllerImpl implements DownloadController {
             InputStream is = getClass().getResourceAsStream("/templates/subscriptionsTemplate.json");
             return new ResponseEntity<>(IOUtils.toByteArray(is), HttpStatus.OK);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>("Subscriptions template file is not found", HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            String errorMessage = "Failed to download subscriptions template file. Error message:\n" + e.getMessage();
-            LOGGER.error(e.getMessage(), e);
+            String errorMessage = "Internal Server Error: Failed to download subscriptions template file.";
+            LOGGER.error(e.getMessage(), ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -75,11 +76,11 @@ public class DownloadControllerImpl implements DownloadController {
             InputStream is = getClass().getResourceAsStream("/templates/rulesTemplate.json");
             return new ResponseEntity<>(IOUtils.toByteArray(is), HttpStatus.OK);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>("Rules template file is not found", HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            String errorMessage = "Failed to download rules template file. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to download rules template file.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -90,11 +91,11 @@ public class DownloadControllerImpl implements DownloadController {
             InputStream is = getClass().getResourceAsStream("/templates/eventsTemplate.json");
             return new ResponseEntity<>(IOUtils.toByteArray(is), HttpStatus.OK);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>("Events template file is not found", HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            String errorMessage = "Failed to download events template file. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to download events template file.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
@@ -59,7 +59,11 @@ public class DownloadControllerImpl implements DownloadController {
     public ResponseEntity<?> getDownloadSubscriptionsTemplate() {
         try {
             InputStream is = getClass().getResourceAsStream("/templates/subscriptionsTemplate.json");
-
+            if (is == null) {
+                String errorMessage = "Subscriptions template file is not found.";
+                LOGGER.error(errorMessage);
+                return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.NOT_FOUND);
+            }
             return new ResponseEntity<>(IOUtils.toByteArray(is), HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to download subscriptions template file.";

--- a/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
@@ -28,6 +28,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+import com.ericsson.ei.utils.ResponseMessage;
+
 import io.swagger.annotations.Api;
 
 @Component
@@ -48,7 +50,7 @@ public class DownloadControllerImpl implements DownloadController {
         } catch (Exception e) {
             String errorMessage = "Failed to get information about download endpoints. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -63,7 +65,7 @@ public class DownloadControllerImpl implements DownloadController {
         } catch (Exception e) {
             String errorMessage = "Failed to download subscriptions template file. Error message:\n" + e.getMessage();
             LOGGER.error(e.getMessage(), e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -78,7 +80,7 @@ public class DownloadControllerImpl implements DownloadController {
         } catch (Exception e) {
             String errorMessage = "Failed to download rules template file. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -93,7 +95,7 @@ public class DownloadControllerImpl implements DownloadController {
         } catch (Exception e) {
             String errorMessage = "Failed to download events template file. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/DownloadControllerImpl.java
@@ -16,11 +16,9 @@
 */
 package com.ericsson.ei.controller;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
@@ -14,6 +14,7 @@
 package com.ericsson.ei.controller;
 
 import com.ericsson.ei.controller.model.ParseInstanceInfoEI;
+import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -45,7 +46,7 @@ public class InformationControllerImpl implements InformationController {
         } catch (Exception e) {
             String errorMessage = "Failed to parse EI backend information. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
@@ -18,6 +18,8 @@ import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,8 +46,8 @@ public class InformationControllerImpl implements InformationController {
             LOGGER.debug("EI backend information is parsed successfully");
             return new ResponseEntity<>(info, HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = "Failed to parse EI backend information. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage);
+            String errorMessage = "Internal Server Error: Failed to parse EI backend information.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
@@ -47,7 +47,7 @@ public class InformationControllerImpl implements InformationController {
             return new ResponseEntity<>(info, HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to parse EI backend information.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
@@ -47,7 +47,8 @@ public class InformationControllerImpl implements InformationController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to parse EI backend information.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectController.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectController.java
@@ -1,7 +1,6 @@
 
 package com.ericsson.ei.controller;
 
-import com.ericsson.ei.controller.model.QueryResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +25,7 @@ public interface QueryAggregatedObjectController {
      * 
      */
     @RequestMapping(value = "", method = RequestMethod.GET)
-    public ResponseEntity<QueryResponse> getQueryAggregatedObject(
+    public ResponseEntity<?> getQueryAggregatedObject(
         @RequestParam
         String id);
 

--- a/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
@@ -67,7 +67,8 @@ public class QueryAggregatedObjectControllerImpl implements QueryAggregatedObjec
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to extract the aggregated data from the Aggregated Object based on ID " + id + ".";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.ericsson.ei.controller.model.QueryResponse;
 import com.ericsson.ei.controller.model.QueryResponseEntity;
 import com.ericsson.ei.queryservice.ProcessAggregatedObject;
+import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 
@@ -51,7 +52,7 @@ public class QueryAggregatedObjectControllerImpl implements QueryAggregatedObjec
      * @return ResponseEntity
      */
     @Override
-    public ResponseEntity<QueryResponse> getQueryAggregatedObject(@RequestParam("ID") final String id) {
+    public ResponseEntity<?> getQueryAggregatedObject(@RequestParam("ID") final String id) {
         ObjectMapper mapper = new ObjectMapper();
         QueryResponseEntity queryResponseEntity = new QueryResponseEntity();
         QueryResponse queryResponse = new QueryResponse();
@@ -70,8 +71,7 @@ public class QueryAggregatedObjectControllerImpl implements QueryAggregatedObjec
             String errorMessage = "Failed to extract the aggregated data from the Aggregated Object based on ID " + id
                     + ". Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            queryResponse.setAdditionalProperty("errorMessage", errorMessage);
-            return new ResponseEntity<>(queryResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
@@ -15,6 +15,7 @@ package com.ericsson.ei.controller;
 
 import java.util.List;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,10 +31,8 @@ import com.ericsson.ei.queryservice.ProcessAggregatedObject;
 import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-
 /**
- * This class represents the REST GET mechanism to extract the aggregated data
- * on the basis of the ID from the aggregatedObject.
+ * This class represents the REST GET mechanism to extract the aggregated data on the basis of the ID from the aggregatedObject.
  */
 @Component
 @CrossOrigin
@@ -45,8 +44,7 @@ public class QueryAggregatedObjectControllerImpl implements QueryAggregatedObjec
     private ProcessAggregatedObject processAggregatedObject;
 
     /**
-     * This method is responsible for the REST Get mechanism to extract the
-     * aggregated data on the basis of the ID from the aggregatedObject.
+     * This method is responsible for the REST Get mechanism to extract the aggregated data on the basis of the ID from the aggregatedObject.
      *
      * @param id
      * @return ResponseEntity
@@ -68,9 +66,8 @@ public class QueryAggregatedObjectControllerImpl implements QueryAggregatedObjec
             LOGGER.debug("The response is: " + response.toString());
             return new ResponseEntity<>(queryResponse, httpStatus);
         } catch (Exception e) {
-            String errorMessage = "Failed to extract the aggregated data from the Aggregated Object based on ID " + id
-                    + ". Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to extract the aggregated data from the Aggregated Object based on ID " + id + ".";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
@@ -67,7 +67,7 @@ public class QueryAggregatedObjectControllerImpl implements QueryAggregatedObjec
             return new ResponseEntity<QueryResponse>(queryResponse, httpStatus);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to extract the aggregated data from the Aggregated Object based on ID " + id + ".";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
@@ -64,7 +64,7 @@ public class QueryAggregatedObjectControllerImpl implements QueryAggregatedObjec
 
             queryResponse.setQueryResponseEntity(queryResponseEntity);
             LOGGER.debug("The response is: " + response.toString());
-            return new ResponseEntity<>(queryResponse, httpStatus);
+            return new ResponseEntity<QueryResponse>(queryResponse, httpStatus);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to extract the aggregated data from the Aggregated Object based on ID " + id + ".";
             LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));

--- a/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryAggregatedObjectControllerImpl.java
@@ -15,7 +15,6 @@ package com.ericsson.ei.controller;
 
 import java.util.List;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
@@ -16,6 +16,7 @@
 */
 package com.ericsson.ei.controller;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -73,8 +74,8 @@ public class QueryControllerImpl implements QueryController {
             }
             return new ResponseEntity<>(result.toString(), httpStatus);
         } catch (Exception e) {
-            String errorMessage = "Failed to extract data from the Aggregated Object using freestyle query. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to extract data from the Aggregated Object using freestyle query.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
@@ -75,7 +75,8 @@ public class QueryControllerImpl implements QueryController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to extract data from the Aggregated Object using freestyle query.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import com.ericsson.ei.controller.model.QueryBody;
 import com.ericsson.ei.queryservice.ProcessQueryParams;
+import com.ericsson.ei.utils.ResponseMessage;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -74,7 +75,7 @@ public class QueryControllerImpl implements QueryController {
         } catch (Exception e) {
             String errorMessage = "Failed to extract data from the Aggregated Object using freestyle query. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
@@ -75,7 +75,7 @@ public class QueryControllerImpl implements QueryController {
             return new ResponseEntity<>(result.toString(), httpStatus);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to extract data from the Aggregated Object using freestyle query.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryControllerImpl.java
@@ -16,7 +16,6 @@
 */
 package com.ericsson.ei.controller;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationController.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationController.java
@@ -1,7 +1,6 @@
 
 package com.ericsson.ei.controller;
 
-import com.ericsson.ei.controller.model.QueryResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +25,7 @@ public interface QueryMissedNotificationController {
      * 
      */
     @RequestMapping(value = "", method = RequestMethod.GET)
-    public ResponseEntity<QueryResponse> getQueryMissedNotifications(
+    public ResponseEntity<?> getQueryMissedNotifications(
         @RequestParam
         String subscriptionName);
 

--- a/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
@@ -70,7 +70,7 @@ public class QueryMissedNotificationControllerImpl implements QueryMissedNotific
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to extract the data from the Missed Notification Object based on subscription name "
                     + subscriptionName + ".";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
@@ -70,7 +70,8 @@ public class QueryMissedNotificationControllerImpl implements QueryMissedNotific
             String errorMessage = "Internal Server Error: Failed to extract the data from the Missed Notification Object based on subscription name "
                     + subscriptionName + ".";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.ericsson.ei.controller.model.QueryResponse;
 import com.ericsson.ei.controller.model.QueryResponseEntity;
 import com.ericsson.ei.queryservice.ProcessMissedNotification;
+import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -50,7 +51,7 @@ public class QueryMissedNotificationControllerImpl implements QueryMissedNotific
      * @return ResponseEntity
      */
     @Override
-    public ResponseEntity<QueryResponse> getQueryMissedNotifications(
+    public ResponseEntity<?> getQueryMissedNotifications(
             @RequestParam("SubscriptionName") final String subscriptionName) {
         ObjectMapper mapper = new ObjectMapper();
         QueryResponse queryResponse = new QueryResponse();
@@ -70,10 +71,8 @@ public class QueryMissedNotificationControllerImpl implements QueryMissedNotific
         } catch (Exception e) {
             String errorMessage = "Failed to extract the data from the Missed Notification Object based on subscription name "
                     + subscriptionName + ". Error message:\n" + e.getMessage();
-            queryResponseEntity.setAdditionalProperty("errorMessage", errorMessage);
             LOGGER.error(errorMessage, e);
-            queryResponse.setQueryResponseEntity(queryResponseEntity);
-            return new ResponseEntity<>(queryResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
@@ -15,6 +15,7 @@ package com.ericsson.ei.controller;
 
 import java.util.List;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,8 @@ import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * This class represents the REST GET mechanism to extract the aggregated data
- * on the basis of the SubscriptionName from the Missed Notification Object.
+ * This class represents the REST GET mechanism to extract the aggregated data on the basis of the SubscriptionName from the Missed Notification
+ * Object.
  */
 @Component
 @CrossOrigin
@@ -44,15 +45,14 @@ public class QueryMissedNotificationControllerImpl implements QueryMissedNotific
     private ProcessMissedNotification processMissedNotification;
 
     /**
-     * This method is responsible for the REST GET mechanism to extract the data on
-     * the basis of the SubscriptionName from the Missed Notification Object.
+     * This method is responsible for the REST GET mechanism to extract the data on the basis of the SubscriptionName from the Missed Notification
+     * Object.
      *
      * @param subscriptionName
      * @return ResponseEntity
      */
     @Override
-    public ResponseEntity<?> getQueryMissedNotifications(
-            @RequestParam("SubscriptionName") final String subscriptionName) {
+    public ResponseEntity<?> getQueryMissedNotifications(@RequestParam("SubscriptionName") final String subscriptionName) {
         ObjectMapper mapper = new ObjectMapper();
         QueryResponse queryResponse = new QueryResponse();
         QueryResponseEntity queryResponseEntity = new QueryResponseEntity();
@@ -64,14 +64,13 @@ public class QueryMissedNotificationControllerImpl implements QueryMissedNotific
             queryResponse.setQueryResponseEntity(queryResponseEntity);
             LOGGER.debug("The response is : " + response.toString());
             if (processMissedNotification.deleteMissedNotification(subscriptionName)) {
-                LOGGER.debug("Missed notification with subscription name " + subscriptionName
-                        + " was successfully removed from database");
+                LOGGER.debug("Missed notification with subscription name " + subscriptionName + " was successfully removed from database");
             }
             return new ResponseEntity<>(queryResponse, HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = "Failed to extract the data from the Missed Notification Object based on subscription name "
-                    + subscriptionName + ". Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to extract the data from the Missed Notification Object based on subscription name "
+                    + subscriptionName + ".";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
@@ -15,7 +15,6 @@ package com.ericsson.ei.controller;
 
 import java.util.List;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
@@ -18,6 +18,7 @@ package com.ericsson.ei.controller;
 
 import java.io.IOException;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -104,7 +105,7 @@ public class RuleCheckControllerImpl implements RuleCheckController {
             return new ResponseEntity<>(res, HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Failed to run rule on event. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.BAD_REQUEST);
         }
     }
@@ -121,14 +122,13 @@ public class RuleCheckControllerImpl implements RuleCheckController {
                 if (aggregatedObject != null && !aggregatedObject.equals("[]")) {
                     return new ResponseEntity<>(aggregatedObject, HttpStatus.OK);
                 } else {
-                    String message = "Aggregated event is not generated. List of rules or list of events are not correct";
-                    String errorMessage = "Failed to generate aggregated object. Error message:\n" + message;
+                    String errorMessage = "Failed to generate aggregated object. List of rules or list of events are not correct";
                     LOGGER.error(errorMessage);
                     return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.BAD_REQUEST);
                 }
             } catch (JSONException | IOException e) {
-                String errorMessage = "Failed to generate aggregated object. Error message:\n" + e.getMessage();
-                LOGGER.error(errorMessage, e);
+                String errorMessage = "Internal Server Error: Failed to generate aggregated object.";
+                LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
                 return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
             }
         } else {
@@ -148,8 +148,8 @@ public class RuleCheckControllerImpl implements RuleCheckController {
         try {
             return new ResponseEntity<>(new JSONObject().put("status", testEnable).toString(), HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = "Failed to get Status. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, e);
+            String errorMessage = "Internal Server Error: Failed to get Status.";
+            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
@@ -105,7 +105,8 @@ public class RuleCheckControllerImpl implements RuleCheckController {
         } catch (Exception e) {
             String errorMessage = "Failed to run rule on event. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.BAD_REQUEST);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -123,19 +124,22 @@ public class RuleCheckControllerImpl implements RuleCheckController {
                 } else {
                     String errorMessage = "Failed to generate aggregated object. List of rules or list of events are not correct";
                     LOGGER.error(errorMessage);
-                    return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.BAD_REQUEST);
+                    String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+                    return new ResponseEntity<>(errorJsonAsString, HttpStatus.BAD_REQUEST);
                 }
             } catch (JSONException | IOException e) {
                 String errorMessage = "Internal Server Error: Failed to generate aggregated object.";
                 LOGGER.error(errorMessage, e);
-                return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+                String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+                return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
             }
         } else {
             String errorMessage = "Test Rules functionality is disabled in backend server. "
                     + "Configure \"testaggregated.controller.enabled\" setting in backend servers properties "
                     + "to enable this functionality. This should normally only be enabled in backend test servers.";
             LOGGER.error(errorMessage);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.SERVICE_UNAVAILABLE);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.SERVICE_UNAVAILABLE);
         }
     }
 
@@ -149,7 +153,8 @@ public class RuleCheckControllerImpl implements RuleCheckController {
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to get Status.";
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
@@ -35,6 +35,7 @@ import com.ericsson.ei.controller.model.RuleCheckBody;
 import com.ericsson.ei.controller.model.RulesCheckBody;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.services.IRuleCheckService;
+import com.ericsson.ei.utils.ResponseMessage;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -104,7 +105,7 @@ public class RuleCheckControllerImpl implements RuleCheckController {
         } catch (Exception e) {
             String errorMessage = "Failed to run rule on event. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -120,21 +121,22 @@ public class RuleCheckControllerImpl implements RuleCheckController {
                 if (aggregatedObject != null && !aggregatedObject.equals("[]")) {
                     return new ResponseEntity<>(aggregatedObject, HttpStatus.OK);
                 } else {
-                    String errorMessage = "Aggregated event is not generated. List of rules or list of events are not correct";
+                    String message = "Aggregated event is not generated. List of rules or list of events are not correct";
+                    String errorMessage = "Failed to generate aggregated object. Error message:\n" + message;
                     LOGGER.error(errorMessage);
-                    return new ResponseEntity<>(errorMessage, HttpStatus.BAD_REQUEST);
+                    return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.BAD_REQUEST);
                 }
             } catch (JSONException | IOException e) {
                 String errorMessage = "Failed to generate aggregated object. Error message:\n" + e.getMessage();
                 LOGGER.error(errorMessage, e);
-                return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+                return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
             }
         } else {
             String errorMessage = "Test Rules functionality is disabled in backend server. "
                     + "Configure \"testaggregated.controller.enabled\" setting in backend servers properties "
                     + "to enable this functionality. This should normally only be enabled in backend test servers.";
             LOGGER.error(errorMessage);
-            return new ResponseEntity<>(errorMessage, HttpStatus.SERVICE_UNAVAILABLE);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.SERVICE_UNAVAILABLE);
         }
     }
 
@@ -148,7 +150,7 @@ public class RuleCheckControllerImpl implements RuleCheckController {
         } catch (Exception e) {
             String errorMessage = "Failed to get Status. Error message:\n" + e.getMessage();
             LOGGER.error(errorMessage, e);
-            return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
@@ -18,7 +18,6 @@ package com.ericsson.ei.controller;
 
 import java.io.IOException;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleCheckControllerImpl.java
@@ -105,7 +105,7 @@ public class RuleCheckControllerImpl implements RuleCheckController {
             return new ResponseEntity<>(res, HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Failed to run rule on event. Error message:\n" + e.getMessage();
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.BAD_REQUEST);
         }
     }
@@ -128,7 +128,7 @@ public class RuleCheckControllerImpl implements RuleCheckController {
                 }
             } catch (JSONException | IOException e) {
                 String errorMessage = "Internal Server Error: Failed to generate aggregated object.";
-                LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+                LOGGER.error(errorMessage, e);
                 return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
             }
         } else {
@@ -149,7 +149,7 @@ public class RuleCheckControllerImpl implements RuleCheckController {
             return new ResponseEntity<>(new JSONObject().put("status", testEnable).toString(), HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to get Status.";
-            LOGGER.error(errorMessage, ExceptionUtils.getStackTrace(e));
+            LOGGER.error(errorMessage, e);
             return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionController.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionController.java
@@ -3,7 +3,6 @@ package com.ericsson.ei.controller;
 
 import java.util.List;
 import javax.validation.Valid;
-import com.ericsson.ei.controller.model.GetSubscriptionResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,7 +35,7 @@ public interface SubscriptionController {
      * 
      */
     @RequestMapping(value = "", method = RequestMethod.POST)
-    public ResponseEntity<List<com.ericsson.ei.controller.model.SubscriptionResponse>> createSubscription(
+    public ResponseEntity<?> createSubscription(
         @Valid
         @RequestBody
         List<com.ericsson.ei.controller.model.Subscription> subscription);
@@ -46,7 +45,7 @@ public interface SubscriptionController {
      * 
      */
     @RequestMapping(value = "", method = RequestMethod.PUT)
-    public ResponseEntity<List<com.ericsson.ei.controller.model.SubscriptionResponse>> updateSubscriptions(
+    public ResponseEntity<?> updateSubscriptions(
         @Valid
         @RequestBody
         List<com.ericsson.ei.controller.model.Subscription> subscription);
@@ -56,7 +55,7 @@ public interface SubscriptionController {
      * 
      */
     @RequestMapping(value = "/{subscriptionNames}", method = RequestMethod.GET)
-    public ResponseEntity<GetSubscriptionResponse> getSubscriptionByNames(
+    public ResponseEntity<?> getSubscriptionByNames(
         @PathVariable
         String subscriptionNames);
 
@@ -65,7 +64,7 @@ public interface SubscriptionController {
      * 
      */
     @RequestMapping(value = "/{subscriptionNames}", method = RequestMethod.DELETE)
-    public ResponseEntity<List<com.ericsson.ei.controller.model.SubscriptionResponse>> deleteSubscriptionByNames(
+    public ResponseEntity<?> deleteSubscriptionByNames(
         @PathVariable
         String subscriptionNames);
 

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,8 +93,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                     errorMap.put(subscriptionName, SUBSCRIPTION_ALREADY_EXISTS);
                 }
             } catch (Exception e) {
-                LOG.error("Failed to create subscription " + subscriptionName + "\nError message: " + e.getMessage(),
-                        e);
+                LOG.error("Failed to create subscription " + subscriptionName, ExceptionUtils.getStackTrace(e));
                 errorMap.put(subscriptionName, e.getMessage());
             }
         });
@@ -119,10 +119,10 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                 foundSubscriptionList.add(subscription);
                 LOG.debug("Subscription [" + subscriptionName + "] fetched successfully.");
             } catch (SubscriptionNotFoundException e) {
-                LOG.error("Subscription not found: " + subscriptionName);
+                LOG.error("Subscription not found: " + subscriptionName, ExceptionUtils.getStackTrace(e));
                 notFoundSubscriptionList.add(subscriptionName);
             } catch (Exception e) {
-                LOG.error("Failed to fetch subscription " + subscriptionName + "\nError message: " + e.getMessage(), e);
+                LOG.error("Failed to fetch subscription " + subscriptionName, ExceptionUtils.getStackTrace(e));
                 notFoundSubscriptionList.add(subscriptionName);
             }
         });
@@ -160,8 +160,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                     errorMap.put(subscriptionName, SUBSCRIPTION_NOT_FOUND);
                 }
             } catch (Exception e) {
-                LOG.error("Failed to update subscription " + subscriptionName + "\nError message: " + e.getMessage(),
-                        e);
+                LOG.error("Failed to update subscription " + subscriptionName, ExceptionUtils.getStackTrace(e));
                 errorMap.put(subscriptionName, e.getMessage());
             }
         });
@@ -188,11 +187,10 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                     errorMap.put(subscriptionName, SUBSCRIPTION_NOT_FOUND);
                 }
             } catch (AccessException e) {
-                LOG.error("Error: " + e.getMessage());
+                LOG.error("Failed to delete subscription: " + subscriptionName, ExceptionUtils.getStackTrace(e));
                 errorMap.put(subscriptionName, INVALID_USER);
             } catch (Exception e) {
-                String errorMessage = "Failed to delete subscriptions. Error message:\n" + e.getMessage();
-                LOG.error(errorMessage, e);
+                LOG.error("Failed to delete subscriptions.", ExceptionUtils.getStackTrace(e));
                 errorMap.put(subscriptionName, e.getClass().toString() + " : " + e.getMessage());
             }
         });
@@ -213,11 +211,10 @@ public class SubscriptionControllerImpl implements SubscriptionController {
 
             return new ResponseEntity<>(subscriptions, HttpStatus.OK);
         } catch (SubscriptionNotFoundException e) {
-            LOG.info(e.getMessage());
+            LOG.info(ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = "Failed to fetch subscriptions. Error message:\n" + e.getMessage();
-            LOG.error(errorMessage, e);
+            LOG.error("Internal Server Error: Failed to fetch subscriptions.", ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -211,7 +210,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
 
             return new ResponseEntity<>(subscriptions, HttpStatus.OK);
         } catch (SubscriptionNotFoundException e) {
-            LOG.info(ExceptionUtils.getStackTrace(e));
+            LOG.info(e.getMessage(),e);
             return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
         } catch (Exception e) {
             LOG.error("Internal Server Error: Failed to fetch subscriptions.", e);

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -208,7 +208,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             return new ResponseEntity<>(subscriptions, HttpStatus.OK);
         } catch (SubscriptionNotFoundException e) {
             LOG.info(e.getMessage(),e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(e.getMessage()), HttpStatus.OK);
+            return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Failed to fetch subscriptions.";
             LOG.error("Internal Server Error: {}", errorMessage, e);

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -93,7 +93,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                     errorMap.put(subscriptionName, SUBSCRIPTION_ALREADY_EXISTS);
                 }
             } catch (Exception e) {
-                LOG.error("Failed to create subscription " + subscriptionName, ExceptionUtils.getStackTrace(e));
+                LOG.error("Failed to create subscription " + subscriptionName, e);
                 errorMap.put(subscriptionName, e.getMessage());
             }
         });
@@ -119,10 +119,10 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                 foundSubscriptionList.add(subscription);
                 LOG.debug("Subscription [" + subscriptionName + "] fetched successfully.");
             } catch (SubscriptionNotFoundException e) {
-                LOG.error("Subscription not found: " + subscriptionName, ExceptionUtils.getStackTrace(e));
+                LOG.error("Subscription not found: " + subscriptionName, e);
                 notFoundSubscriptionList.add(subscriptionName);
             } catch (Exception e) {
-                LOG.error("Failed to fetch subscription " + subscriptionName, ExceptionUtils.getStackTrace(e));
+                LOG.error("Failed to fetch subscription " + subscriptionName, e);
                 notFoundSubscriptionList.add(subscriptionName);
             }
         });
@@ -160,7 +160,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                     errorMap.put(subscriptionName, SUBSCRIPTION_NOT_FOUND);
                 }
             } catch (Exception e) {
-                LOG.error("Failed to update subscription " + subscriptionName, ExceptionUtils.getStackTrace(e));
+                LOG.error("Failed to update subscription " + subscriptionName, e);
                 errorMap.put(subscriptionName, e.getMessage());
             }
         });
@@ -187,10 +187,10 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                     errorMap.put(subscriptionName, SUBSCRIPTION_NOT_FOUND);
                 }
             } catch (AccessException e) {
-                LOG.error("Failed to delete subscription: " + subscriptionName, ExceptionUtils.getStackTrace(e));
+                LOG.error("Failed to delete subscription: " + subscriptionName, e);
                 errorMap.put(subscriptionName, INVALID_USER);
             } catch (Exception e) {
-                LOG.error("Failed to delete subscriptions.", ExceptionUtils.getStackTrace(e));
+                LOG.error("Failed to delete subscriptions.", e);
                 errorMap.put(subscriptionName, e.getClass().toString() + " : " + e.getMessage());
             }
         });
@@ -214,7 +214,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             LOG.info(ExceptionUtils.getStackTrace(e));
             return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
         } catch (Exception e) {
-            LOG.error("Internal Server Error: Failed to fetch subscriptions.", ExceptionUtils.getStackTrace(e));
+            LOG.error("Internal Server Error: Failed to fetch subscriptions.", e);
             return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -128,7 +128,8 @@ public class SubscriptionControllerImpl implements SubscriptionController {
         HttpStatus httpStatus = (!foundSubscriptionList.isEmpty()) ? HttpStatus.OK : HttpStatus.NOT_FOUND;
         if (httpStatus == HttpStatus.NOT_FOUND) {
             String errorMessage = "Failed to fetch subscriptions:\n" + notFoundSubscriptionList.toString();
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), httpStatus);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, httpStatus);
         }
         return new ResponseEntity<>(response, httpStatus);
     }
@@ -212,7 +213,8 @@ public class SubscriptionControllerImpl implements SubscriptionController {
         } catch (Exception e) {
             String errorMessage = "Failed to fetch subscriptions.";
             LOG.error("Internal Server Error: {}", errorMessage, e);
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -236,7 +238,8 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             for (Map.Entry<String, String> entry : errorMap.entrySet()) {
                 errorMessage += "" + entry.getKey() + " :: " + entry.getValue() + "\n";
             }
-            return new ResponseEntity<>(ResponseMessage.createJsonMessage(errorMessage), HttpStatus.BAD_REQUEST);
+            String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
+            return new ResponseEntity<>(errorJsonAsString, HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/com/ericsson/ei/utils/ResponseMessage.java
+++ b/src/main/java/com/ericsson/ei/utils/ResponseMessage.java
@@ -2,10 +2,25 @@ package com.ericsson.ei.utils;
 
 import org.json.JSONObject;
 
+/**
+ * Contains a single method that is used in the controller classes to put error response messages in
+ * a JSON formatted string.
+ *
+ * @author ezcorch
+ *
+ */
 public class ResponseMessage {
     private static final String KEY = "message";
 
+    /**
+     * Puts the message in a JSON formatted key value pair. The key name is "message" and the value
+     * is the provided message.
+     *
+     * @param message
+     *            the message to wrap
+     * @return the formatted string
+     */
     public static String createJsonMessage(String message) {
-        return new JSONObject().put(KEY, message).toString();  
+        return new JSONObject().put(KEY, message).toString();
     }
 }

--- a/src/main/java/com/ericsson/ei/utils/ResponseMessage.java
+++ b/src/main/java/com/ericsson/ei/utils/ResponseMessage.java
@@ -1,0 +1,11 @@
+package com.ericsson.ei.utils;
+
+import org.json.JSONObject;
+
+public class ResponseMessage {
+    private static final String KEY = "message";
+
+    public static String createJsonMessage(String message) {
+        return new JSONObject().put(KEY, message).toString();  
+    }
+}

--- a/src/main/resources/public/raml/resourceTypes/query-aggregated_object.raml
+++ b/src/main/resources/public/raml/resourceTypes/query-aggregated_object.raml
@@ -10,4 +10,3 @@ get:
     200:
       body:
         application/json:
-          schema: stringServiceResponse

--- a/src/main/resources/public/raml/resourceTypes/query-missed_notifications.raml
+++ b/src/main/resources/public/raml/resourceTypes/query-missed_notifications.raml
@@ -11,4 +11,3 @@ get:
     200:
       body:
         application/json:
-          schema: stringServiceResponse

--- a/src/main/resources/public/raml/resourceTypes/subscription.raml
+++ b/src/main/resources/public/raml/resourceTypes/subscription.raml
@@ -17,7 +17,6 @@
         200:
           body:
             application/json:
-              schema: subscriptionResponse
 
     put:
       description: Modify existing Subscriptions.
@@ -28,7 +27,6 @@
         200:
           body:
             application/json:
-              schema: subscriptionResponse
 
     /{subscriptionNames}:
       uriParameters:
@@ -44,9 +42,6 @@
           200:        
             body:
               application/json:
-                schema: getSubscriptionResponse
-
-
 
       delete:
         description: Removes the subscriptions from the database for the given subscription names.
@@ -54,4 +49,3 @@
           200:
             body:
               application/json:
-                schema: subscriptionResponse

--- a/src/test/java/com/ericsson/ei/services/SubscriptionRestAPITest.java
+++ b/src/test/java/com/ericsson/ei/services/SubscriptionRestAPITest.java
@@ -249,11 +249,11 @@ public class SubscriptionRestAPITest {
                 .accept(MediaType.APPLICATION_JSON);
 
         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
-
-        JSONArray notFoundSubscriptions = new JSONObject(result.getResponse().getContentAsString()).getJSONArray(NOT_FOUND_SUBSCRIPTIONS_ARRAY);
+        
+        String errorMessage = new JSONObject(result.getResponse().getContentAsString()).getString("message");
 
         assertEquals(HttpStatus.NOT_FOUND.value(), result.getResponse().getStatus());
-        assertEquals("Subscription_Test_Not_Found", notFoundSubscriptions.get(0).toString());
+        assertEquals(true, errorMessage.contains("Subscription_Test_Not_Found"));
     }
 
     @Test


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
An attempt to standardize error response. 
- Controllers with strict response types have been made generic to be able to return whatever.
- Error response are returned as a JSON string with a key value pair: {"message":"error"}

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
