### PR TITLE
Reduce and improve logs during test executions

### DIFF
--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -115,11 +115,11 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                 LOGGER.debug("Subscription [{}] fetched successfully.", subscriptionName);
             } catch (SubscriptionNotFoundException e) {
                 LOGGER.error("Subscription not found: {}", subscriptionName);
-                LOGGER.debug("Subscription not found traceback", e);
+                LOGGER.debug("Subscription not found traceback:\n {}", e);
                 notFoundSubscriptionList.add(subscriptionName);
             } catch (Exception e) {
-                LOGGER.error("Failed to fetch subscription {}", subscriptionName, e);
-                LOGGER.debug("Failed to fetch subscription {}", e);
+                LOGGER.error("Failed to fetch subscription {}", subscriptionName);
+                LOGGER.debug("Failed to fetch subscription:\n {}", e);
 
                 notFoundSubscriptionList.add(subscriptionName);
             }

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -114,10 +114,13 @@ public class SubscriptionControllerImpl implements SubscriptionController {
                 foundSubscriptionList.add(subscription);
                 LOGGER.debug("Subscription [{}] fetched successfully.", subscriptionName);
             } catch (SubscriptionNotFoundException e) {
-                LOGGER.error("Subscription not found: {}",subscriptionName , e);
+                LOGGER.error("Subscription not found: {}", subscriptionName);
+                LOGGER.debug("Subscription not found traceback", e);
                 notFoundSubscriptionList.add(subscriptionName);
             } catch (Exception e) {
                 LOGGER.error("Failed to fetch subscription {}", subscriptionName, e);
+                LOGGER.debug("Failed to fetch subscription {}", e);
+
                 notFoundSubscriptionList.add(subscriptionName);
             }
         });

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -275,7 +275,7 @@ public class MongoDBHandler {
             collectionList = db.listCollectionNames().into(new ArrayList<String>());
         }
         catch (MongoCommandException e) {
-                LOGGER.error("MongoCommandException, MongoDB shudown or interrupted Error: " + e.getErrorMessage() + "\nStactrace\n" + e);
+                LOGGER.error("MongoCommandException, Something went wrong with MongoDb connection. Error: " + e.getErrorMessage() + "\nStactrace\n" + e);
                 if (mongoClient != null) {
                     mongoClient.close();
                 }
@@ -283,7 +283,7 @@ public class MongoDBHandler {
                 return null;
         }
         catch (MongoInterruptedException e) {
-            LOGGER.error(" MongoInterruptedException, MongoDB shudown or interrupted Error: " + e.getMessage() + "\nStactrace\n" + e);
+            LOGGER.error(" MongoInterruptedException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStactrace\n" + e);
             if (mongoClient != null) {
                 mongoClient.close();
             }
@@ -291,7 +291,7 @@ public class MongoDBHandler {
             return null;
         }
         catch (MongoSocketReadException e) {
-            LOGGER.error("MongoSocketReadException, MongoDB shudown or interrupted Error: " + e.getMessage() + "\nStactrace\n" + e);
+            LOGGER.error("MongoSocketReadException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStactrace\n" + e);
             if (mongoClient != null) {
                 mongoClient.close();
             }
@@ -300,7 +300,7 @@ public class MongoDBHandler {
         }
         
         catch (IllegalStateException e) {
-            LOGGER.error("IllegalStateException, MongoDB state not good Error: " + e.getMessage() + "\nStactrace\n" + e);
+            LOGGER.error("IllegalStateException, MongoDB state not good. Error: " + e.getMessage() + "\nStactrace\n" + e);
             if (mongoClient != null) {
                 mongoClient.close();
             }

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -270,37 +270,51 @@ public class MongoDBHandler {
             return null;
         MongoDatabase db;
         List<String> collectionList;
-        MongoCollection<Document> collection = null;
         try {
             db = mongoClient.getDatabase(dataBaseName);
             collectionList = db.listCollectionNames().into(new ArrayList<String>());
-            if (!collectionList.contains(collectionName)) {           
-                LOGGER.debug("The requested database({}) / collection({}) not available in mongodb, Creating ........", dataBaseName, collectionName);
-                db.createCollection(collectionName);                
-            }    
-            collection = db.getCollection(collectionName);            
         }
         catch (MongoCommandException e) {
             LOGGER.error("MongoCommandException, Something went wrong with MongoDb connection. Error: " + e.getErrorMessage() + "\nStacktrace\n" + e);
-            closeMongoDbConnection();
+            closeMongoDbConecction();
+            return null;
         }
         catch (MongoInterruptedException e) {
             LOGGER.error(" MongoInterruptedException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStacktrace\n" + e);
-            closeMongoDbConnection();
+            closeMongoDbConecction();
+            return null;
         }
         catch (MongoSocketReadException e) {
             LOGGER.error("MongoSocketReadException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStacktrace\n" + e);
-            closeMongoDbConnection();
-        }     
+            closeMongoDbConecction();
+            return null;
+        }
+        
         catch (IllegalStateException e) {
             LOGGER.error("IllegalStateException, MongoDB state not good. Error: " + e.getMessage() + "\nStacktrace\n" + e);
-            closeMongoDbConnection();
-        }                
-
+            closeMongoDbConecction();
+            return null;
+        }
+        
+        if (!collectionList.contains(collectionName)) {
+            LOGGER.debug("The requested database({}) / collection({}) not available in mongodb, Creating ........", dataBaseName, collectionName);
+            try {
+                db.createCollection(collectionName);
+            } catch (MongoCommandException e) {
+                String message = "collection '" + dataBaseName + "." + collectionName + "' already exists";
+                if (e.getMessage().contains(message)) {
+                    LOGGER.warn("A {}.", message, e);
+                } else {
+                    throw e;
+                }
+            }
+            LOGGER.debug("done....");
+        }
+        MongoCollection<Document> collection = db.getCollection(collectionName);
         return collection;
     }
 
-    private void closeMongoDbConnection() {
+    private void closeMongoDbConecction() {
         if (mongoClient != null) {
             mongoClient.close();
         }

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -275,7 +275,7 @@ public class MongoDBHandler {
             collectionList = db.listCollectionNames().into(new ArrayList<String>());
         }
         catch (MongoCommandException e) {
-                LOGGER.error("MongoCommandException, Something went wrong with MongoDb connection. Error: " + e.getErrorMessage() + "\nStactrace\n" + e);
+                LOGGER.error("MongoCommandException, Something went wrong with MongoDb connection. Error: " + e.getErrorMessage() + "\nStacktrace\n" + e);
                 if (mongoClient != null) {
                     mongoClient.close();
                 }
@@ -283,7 +283,7 @@ public class MongoDBHandler {
                 return null;
         }
         catch (MongoInterruptedException e) {
-            LOGGER.error(" MongoInterruptedException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStactrace\n" + e);
+            LOGGER.error(" MongoInterruptedException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStacktrace\n" + e);
             if (mongoClient != null) {
                 mongoClient.close();
             }
@@ -291,7 +291,7 @@ public class MongoDBHandler {
             return null;
         }
         catch (MongoSocketReadException e) {
-            LOGGER.error("MongoSocketReadException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStactrace\n" + e);
+            LOGGER.error("MongoSocketReadException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStacktrace\n" + e);
             if (mongoClient != null) {
                 mongoClient.close();
             }
@@ -300,7 +300,7 @@ public class MongoDBHandler {
         }
         
         catch (IllegalStateException e) {
-            LOGGER.error("IllegalStateException, MongoDB state not good. Error: " + e.getMessage() + "\nStactrace\n" + e);
+            LOGGER.error("IllegalStateException, MongoDB state not good. Error: " + e.getMessage() + "\nStacktrace\n" + e);
             if (mongoClient != null) {
                 mongoClient.close();
             }

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -275,36 +275,24 @@ public class MongoDBHandler {
             collectionList = db.listCollectionNames().into(new ArrayList<String>());
         }
         catch (MongoCommandException e) {
-                LOGGER.error("MongoCommandException, Something went wrong with MongoDb connection. Error: " + e.getErrorMessage() + "\nStacktrace\n" + e);
-                if (mongoClient != null) {
-                    mongoClient.close();
-                }
-                mongoClient = null;
-                return null;
+            LOGGER.error("MongoCommandException, Something went wrong with MongoDb connection. Error: " + e.getErrorMessage() + "\nStacktrace\n" + e);
+            closeMongoDbConecction();
+            return null;
         }
         catch (MongoInterruptedException e) {
             LOGGER.error(" MongoInterruptedException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStacktrace\n" + e);
-            if (mongoClient != null) {
-                mongoClient.close();
-            }
-            mongoClient = null;
+            closeMongoDbConecction();
             return null;
         }
         catch (MongoSocketReadException e) {
             LOGGER.error("MongoSocketReadException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStacktrace\n" + e);
-            if (mongoClient != null) {
-                mongoClient.close();
-            }
-            mongoClient = null;
+            closeMongoDbConecction();
             return null;
         }
         
         catch (IllegalStateException e) {
             LOGGER.error("IllegalStateException, MongoDB state not good. Error: " + e.getMessage() + "\nStacktrace\n" + e);
-            if (mongoClient != null) {
-                mongoClient.close();
-            }
-            mongoClient = null;
+            closeMongoDbConecction();
             return null;
         }
         
@@ -326,6 +314,13 @@ public class MongoDBHandler {
         return collection;
     }
 
+    private void closeMongoDbConecction() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+        mongoClient = null;
+    }
+    
     /**
      * This method is used to drop a collection.
      *

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -35,6 +35,8 @@ import com.mongodb.Block;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoCredential;
+import com.mongodb.MongoInterruptedException;
+import com.mongodb.MongoSocketReadException;
 import com.mongodb.MongoWriteException;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCollection;
@@ -266,8 +268,46 @@ public class MongoDBHandler {
     private MongoCollection<Document> getMongoCollection(String dataBaseName, String collectionName) {
         if (mongoClient == null)
             return null;
-        MongoDatabase db = mongoClient.getDatabase(dataBaseName);
-        List<String> collectionList = db.listCollectionNames().into(new ArrayList<String>());
+        MongoDatabase db;
+        List<String> collectionList;
+        try {
+            db = mongoClient.getDatabase(dataBaseName);
+            collectionList = db.listCollectionNames().into(new ArrayList<String>());
+        }
+        catch (MongoCommandException e) {
+                LOGGER.error("MongoCommandException, MongoDB shudown or interrupted Error: " + e.getErrorMessage() + "\nStactrace\n" + e);
+                if (mongoClient != null) {
+                    mongoClient.close();
+                }
+                mongoClient = null;
+                return null;
+        }
+        catch (MongoInterruptedException e) {
+            LOGGER.error(" MongoInterruptedException, MongoDB shudown or interrupted Error: " + e.getMessage() + "\nStactrace\n" + e);
+            if (mongoClient != null) {
+                mongoClient.close();
+            }
+            mongoClient = null;
+            return null;
+        }
+        catch (MongoSocketReadException e) {
+            LOGGER.error("MongoSocketReadException, MongoDB shudown or interrupted Error: " + e.getMessage() + "\nStactrace\n" + e);
+            if (mongoClient != null) {
+                mongoClient.close();
+            }
+            mongoClient = null;
+            return null;
+        }
+        
+        catch (IllegalStateException e) {
+            LOGGER.error("IllegalStateException, MongoDB state not good Error: " + e.getMessage() + "\nStactrace\n" + e);
+            if (mongoClient != null) {
+                mongoClient.close();
+            }
+            mongoClient = null;
+            return null;
+        }
+        
         if (!collectionList.contains(collectionName)) {
             LOGGER.debug("The requested database({}) / collection({}) not available in mongodb, Creating ........", dataBaseName, collectionName);
             try {

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -291,7 +291,7 @@ public class MongoDBHandler {
         }
         
         catch (IllegalStateException e) {
-            LOGGER.error("IllegalStateException, MongoDB state not good. Error: " + e.getMessage() + "\nStacktrace\n" + e);
+            LOGGER.error("IllegalStateException, MongoDB state not good. Error: " + e.getMessage());
             closeMongoDbConecction();
             return null;
         }

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
@@ -25,6 +25,7 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestOperations;
 
 /**
@@ -61,6 +62,9 @@ public class HttpRequestSender {
             checkIfAuthenticationException(e);
             LOGGER.error("HTTP request failed, bad request! When trying to connect to URL: {}\n{}",
                     url, e);
+            return false;
+        } catch (HttpServerErrorException e) {
+            LOGGER.error("HttpServerErrorException, HTTP request to url {} failed\n", url, e);
             return false;
         } catch (Exception e) {
             LOGGER.error("HTTP request to url {} failed\n", url, e);

--- a/src/test/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandlerTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.ericsson.ei.App;
 import com.ericsson.ei.handlers.MongoDBHandler;
+import com.ericsson.ei.utils.FunctionalTestBase;
 import com.ericsson.ei.utils.TestContextInitializer;
 import com.mongodb.BasicDBObject;
 import com.mongodb.util.JSON;
@@ -43,10 +44,8 @@ import com.mongodb.util.JSON;
         "missedNotificationDataBaseName: SubscriptionRepeatDbHandlerTest-missedNotifications",
         "rabbitmq.exchange.name: SubscriptionRepeatDbHandlerTest-exchange",
         "rabbitmq.consumerName: SubscriptionRepeatDbHandlerTest" })
-@ContextConfiguration(classes = App.class, loader = SpringBootContextLoader.class, initializers = TestContextInitializer.class)
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = { App.class })
-public class SubscriptionRepeatDbHandlerTest {
+public class SubscriptionRepeatDbHandlerTest extends FunctionalTestBase {
 
     static Logger log = LoggerFactory.getLogger(SubscriptionRepeatDbHandlerTest.class);
 

--- a/src/test/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandlerTest.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.utils.FunctionalTestBase;
 import com.mongodb.BasicDBObject;
+import com.mongodb.util.JSON;
 
 @TestPropertySource(properties = {
         "spring.data.mongodb.database: SubscriptionRepeatDbHandlerTest",

--- a/src/test/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandlerTest.java
@@ -26,18 +26,12 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootContextLoader;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.ericsson.ei.App;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.utils.FunctionalTestBase;
-import com.ericsson.ei.utils.TestContextInitializer;
 import com.mongodb.BasicDBObject;
-import com.mongodb.util.JSON;
 
 @TestPropertySource(properties = {
         "spring.data.mongodb.database: SubscriptionRepeatDbHandlerTest",

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,13 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <appender name="STDOUT"
-        class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread])
-                %highlight(%-5level) %logger{36}.%M - %msg%n</pattern>
+            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{36}.%M - %msg%n</pattern>
         </encoder>
     </appender>
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="org.mockserver.mock" level="error" />
 </configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT"
+        class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread])
+                %highlight(%-5level) %logger{36}.%M - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="org.mockserver.mock" level="error" />
+</configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -8,4 +8,5 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
+    <logger name="org.mockserver.mock" level="error" />
 </configuration>


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
Today it has been seen some random, not often, ApplicationContext start issues during tests.
This change is a try to solve that problem and also reduce number exceptions printouts that is printed when embedded mongodb and and embedded messagebus is closed before EI applications has executed finished.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
