### PR TITLE
Fix ERQueryService URI build bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.ericsson</groupId>
-            <artifactId>eiffel-commons-java</artifactId>
-            <version>0.0.15-SNAPSHOT</version>
+            <groupId>com.github.eiffel-community</groupId>
+            <artifactId>eiffel-commons</artifactId>
+            <version>0.0.15</version>
         </dependency>
 
         <dependency>
@@ -511,7 +511,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>3</forkCount>
                     <reuseForks>false</reuseForks>
                     <skipTests>${skipTests}</skipTests>
                     <skipITs>${skipITs}</skipITs>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.eiffel-community</groupId>
-            <artifactId>eiffel-commons</artifactId>
-            <version>0.0.13</version>
+            <groupId>com.github.ericsson</groupId>
+            <artifactId>eiffel-commons-java</artifactId>
+            <version>0.0.15-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -511,7 +511,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <forkCount>3</forkCount>
+                    <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <skipTests>${skipTests}</skipTests>
                     <skipITs>${skipITs}</skipITs>

--- a/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
+++ b/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
@@ -158,16 +158,16 @@ public class ERQueryService {
         final List<LinkType> allLinkTypes = Collections.singletonList(LinkType.ALL);
         switch (searchOption) {
         case DOWN_STREAM:
-            searchParameters.setUlt(new ArrayList<>());
-            searchParameters.setDlt(allLinkTypes);
+            searchParameters.setUpstreamLinkType(new ArrayList<>());
+            searchParameters.setDownstreamLinkType(allLinkTypes);
             break;
         case UP_STREAM:
-            searchParameters.setUlt(allLinkTypes);
-            searchParameters.setDlt(new ArrayList<>());
+            searchParameters.setUpstreamLinkType(allLinkTypes);
+            searchParameters.setDownstreamLinkType(new ArrayList<>());
             break;
         case UP_AND_DOWN_STREAM:
-            searchParameters.setUlt(allLinkTypes);
-            searchParameters.setDlt(allLinkTypes);
+            searchParameters.setUpstreamLinkType(allLinkTypes);
+            searchParameters.setDownstreamLinkType(allLinkTypes);
             break;
         }
 

--- a/src/main/java/com/ericsson/ei/erqueryservice/SearchParameters.java
+++ b/src/main/java/com/ericsson/ei/erqueryservice/SearchParameters.java
@@ -17,8 +17,13 @@
 */
 package com.ericsson.ei.erqueryservice;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A class representation of the POST body to the search API's upstream/downstream method.
@@ -60,8 +65,41 @@ public class SearchParameters {
         this.ult = ult;
     }
 
+    /**
+     * Returns the search parameters as a json string
+     * @return String
+     * @throws IOException
+     */
+    public String getAsJsonString() throws IOException {
+        ArrayList<String> dltStringArray = convertSearchParametersToArrayList(dlt);
+        ArrayList<String> ultStringArray = convertSearchParametersToArrayList(ult);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode dltJson = mapper.readTree(dltStringArray.toString());
+        JsonNode ultJson = mapper.readTree(ultStringArray.toString());
+
+        return "{\"dlt\":" + dltJson.toString() + ",\"ult\":" + ultJson.toString() + "}";
+    }
+
     @Override
     public String toString() {
         return "SearchParameters{" + "dlt=" + dlt + ", ult=" + ult + '}';
+    }
+
+    /**
+     * Converts the searchParameters to a ArrayList with json
+     * @param searchParameters
+     * @return
+     */
+    private ArrayList<String> convertSearchParametersToArrayList(List<LinkType> searchParameters) {
+        Object[] searchParametersArray = searchParameters.toArray();
+        ArrayList<String> searchParametersJsonStringArray = new ArrayList<String>();
+
+        for(int i = 0; i < searchParametersArray.length; i++) {
+            String linkTypeValue = "\"" + searchParametersArray[i].toString() + "\"";
+            searchParametersJsonStringArray.add(linkTypeValue);
+        }
+
+        return searchParametersJsonStringArray;
     }
 }

--- a/src/main/java/com/ericsson/ei/erqueryservice/SearchParameters.java
+++ b/src/main/java/com/ericsson/ei/erqueryservice/SearchParameters.java
@@ -30,15 +30,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class SearchParameters {
 
-    private List<LinkType> dlt;
-    private List<LinkType> ult;
+    private List<LinkType> downstreamLinkType;
+    private List<LinkType> upstreamLinkType;
 
     public SearchParameters() {
     }
 
-    public SearchParameters(final List<LinkType> dlt, final List<LinkType> ult) {
-        this.dlt = dlt;
-        this.ult = ult;
+    public SearchParameters(final List<LinkType> downstreamLinkType, final List<LinkType> upstreamLinkType) {
+        this.downstreamLinkType = downstreamLinkType;
+        this.upstreamLinkType = upstreamLinkType;
     }
 
     private List<LinkType> checkForAll(final List<LinkType> list) {
@@ -49,20 +49,20 @@ public class SearchParameters {
         }
     }
 
-    public List<LinkType> getDlt() {
-        return checkForAll(dlt);
+    public List<LinkType> getDownstreamLinkType() {
+        return checkForAll(downstreamLinkType);
     }
 
-    public void setDlt(final List<LinkType> dlt) {
-        this.dlt = dlt;
+    public void setDownstreamLinkType(final List<LinkType> downstreamLinkType) {
+        this.downstreamLinkType = downstreamLinkType;
     }
 
-    public List<LinkType> getUlt() {
-        return checkForAll(ult);
+    public List<LinkType> getUpstreamLinkType() {
+        return checkForAll(upstreamLinkType);
     }
 
-    public void setUlt(final List<LinkType> ult) {
-        this.ult = ult;
+    public void setUpstreamLinkType(final List<LinkType> upstreamLinkType) {
+        this.upstreamLinkType = upstreamLinkType;
     }
 
     /**
@@ -71,19 +71,19 @@ public class SearchParameters {
      * @throws IOException
      */
     public String getAsJsonString() throws IOException {
-        ArrayList<String> dltStringArray = convertSearchParametersToArrayList(dlt);
-        ArrayList<String> ultStringArray = convertSearchParametersToArrayList(ult);
+        ArrayList<String> downstreamLinkTypeStringArray = convertSearchParametersToArrayList(downstreamLinkType);
+        ArrayList<String> upstreamLinkTypeStringArray = convertSearchParametersToArrayList(upstreamLinkType);
 
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode dltJson = mapper.readTree(dltStringArray.toString());
-        JsonNode ultJson = mapper.readTree(ultStringArray.toString());
+        JsonNode downloadLinkTypeJson = mapper.readTree(downstreamLinkTypeStringArray.toString());
+        JsonNode upstreamLinkTypeJson = mapper.readTree(upstreamLinkTypeStringArray.toString());
 
-        return "{\"dlt\":" + dltJson.toString() + ",\"ult\":" + ultJson.toString() + "}";
+        return "{\"dlt\":" + downloadLinkTypeJson.toString() + ",\"ult\":" + upstreamLinkTypeJson.toString() + "}";
     }
 
     @Override
     public String toString() {
-        return "SearchParameters{" + "dlt=" + dlt + ", ult=" + ult + '}';
+        return "SearchParameters{" + "dlt=" + downstreamLinkType + ", ult=" + upstreamLinkType + '}';
     }
 
     /**

--- a/src/main/java/com/ericsson/ei/handlers/UpStreamEventsHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/UpStreamEventsHandler.java
@@ -45,7 +45,7 @@ public class UpStreamEventsHandler {
     @Autowired
     private RulesHandler rulesHandler;
 
-    public void UpstreamEventsHandler() throws URISyntaxException {
+    public void upstreamEventsHandler() throws URISyntaxException {
         eventRepositoryQueryService = new ERQueryService();
     }
 

--- a/src/main/java/com/ericsson/ei/handlers/UpStreamEventsHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/UpStreamEventsHandler.java
@@ -14,17 +14,21 @@
 
 package com.ericsson.ei.handlers;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import com.ericsson.ei.erqueryservice.ERQueryService;
 import com.ericsson.ei.erqueryservice.SearchOption;
 import com.ericsson.ei.rules.RulesHandler;
 import com.ericsson.ei.rules.RulesObject;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * The Class UpStreamEventsHandler.
@@ -41,8 +45,11 @@ public class UpStreamEventsHandler {
     @Autowired
     private RulesHandler rulesHandler;
 
-    // setters used for injecting mocks
+    public void UpstreamEventsHandler() throws URISyntaxException {
+        eventRepositoryQueryService = new ERQueryService();
+    }
 
+    // setters used for injecting mocks
     public void setEventRepositoryQueryService(final ERQueryService eventRepositoryQueryService) {
         this.eventRepositoryQueryService = eventRepositoryQueryService;
     }
@@ -56,19 +63,23 @@ public class UpStreamEventsHandler {
      *
      * @param aggregatedObjectId
      *                               the aggregated object id
+     * @throws IOException
      */
-    public void runHistoryExtractionRulesOnAllUpstreamEvents(String aggregatedObjectId) {
+    public void runHistoryExtractionRulesOnAllUpstreamEvents(String aggregatedObjectId) throws IOException {
 
         // Use aggregatedObjectId as eventId since they are the same for start
         // events.
-        final ResponseEntity<JsonNode> responseEntity = eventRepositoryQueryService
+        final ResponseEntity responseEntity = eventRepositoryQueryService
                 .getEventStreamDataById(aggregatedObjectId, SearchOption.UP_STREAM, -1, -1, true);
         if (responseEntity == null) {
             LOGGER.warn("Asked for upstream from {} but got null response entity back!", aggregatedObjectId);
             return;
         }
 
-        final JsonNode searchResult = responseEntity.getBody();
+        final String searchResultString = responseEntity.getBody();
+        ObjectMapper mapper = new ObjectMapper();
+        final JsonNode searchResult = mapper.readTree(searchResultString);
+
         if (searchResult == null) {
             LOGGER.warn("Asked for upstream from {} but got null result back!", aggregatedObjectId);
             return;

--- a/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
+++ b/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
@@ -84,7 +84,6 @@ public class ERQueryServiceTest extends Mockito {
 
     @Test
     public void testErQueryUpstream() throws ClientProtocolException, URISyntaxException, IOException {
-//        when(httpExecutor.executeRequest(any(HttpRequestBase.class))).thenAnswer(validateRequest(Mockito.any(HttpRequestBase.class)));
         BDDMockito.given(httpExecutor.executeRequest(any(HttpRequestBase.class))).willAnswer(validateRequest(Mockito.any(HttpRequestBase.class)));
         erQueryService.getEventStreamDataById(eventId, searchOption, limitParam, levels, isTree);
     }

--- a/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
+++ b/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
@@ -66,7 +66,6 @@ public class ERQueryServiceTest extends Mockito {
 
     @Autowired
     private ERQueryService erQueryService;
-    private HttpRequest httpRequest;
     private HttpExecutor httpExecutor;
 
     private String eventId = "01";
@@ -78,7 +77,7 @@ public class ERQueryServiceTest extends Mockito {
     @Before
     public void setUp() throws Exception {
         httpExecutor = mock(HttpExecutor.class);
-        httpRequest = new HttpRequest(HttpMethod.POST, httpExecutor);
+        HttpRequest httpRequest = new HttpRequest(HttpMethod.POST, httpExecutor);
         erQueryService.setHttpRequest(httpRequest);
     }
 
@@ -88,7 +87,7 @@ public class ERQueryServiceTest extends Mockito {
         erQueryService.getEventStreamDataById(eventId, searchOption, limitParam, levels, isTree);
     }
 
-    Answer<ResponseEntity> validateRequest(HttpRequestBase httpRequestBase ) {
+    private Answer<ResponseEntity> validateRequest(HttpRequestBase httpRequestBase ) {
         return invocation -> {
             DefaultHttpResponseFactory responseFactory = new DefaultHttpResponseFactory();
             HttpResponse response = responseFactory.newHttpResponse(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 400, ""), null);

--- a/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
+++ b/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
@@ -1,13 +1,10 @@
 /*
    Copyright 2017 Ericsson AB.
    For a full list of individual contributors, please see the commit history.
-
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-
        http://www.apache.org/licenses/LICENSE-2.0
-
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,44 +14,44 @@
 package com.ericsson.ei.erqueryservice.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.BDDMockito.given;
 
-import java.net.URI;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.DefaultHttpResponseFactory;
+import org.apache.http.message.BasicStatusLine;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.mockito.BDDMockito;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpRequest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.server.ServletServerHttpRequest;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestOperations;
-import org.springframework.web.util.UriComponents;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import com.ericsson.ei.App;
 import com.ericsson.ei.erqueryservice.ERQueryService;
 import com.ericsson.ei.erqueryservice.SearchOption;
-import com.ericsson.ei.erqueryservice.SearchParameters;
 import com.ericsson.ei.utils.TestContextInitializer;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.ericsson.eiffelcommons.utils.HttpExecutor;
+import com.ericsson.eiffelcommons.utils.HttpRequest;
+import com.ericsson.eiffelcommons.utils.HttpRequest.HttpMethod;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+
 
 @TestPropertySource(properties = {
         "spring.data.mongodb.database: ERQueryServiceTest",
@@ -65,13 +62,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 @ContextConfiguration(classes = App.class, loader = SpringBootContextLoader.class, initializers = TestContextInitializer.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = { App.class })
-public class ERQueryServiceTest {
+public class ERQueryServiceTest extends Mockito {
 
     @Autowired
     private ERQueryService erQueryService;
-
-    @Mock
-    private RestOperations rest;
+    private HttpRequest httpRequest;
+    private HttpExecutor httpExecutor;
 
     private String eventId = "01";
     private SearchOption searchOption = SearchOption.UP_STREAM;
@@ -81,83 +77,36 @@ public class ERQueryServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        httpExecutor = mock(HttpExecutor.class);
+        httpRequest = new HttpRequest(HttpMethod.POST, httpExecutor);
+        erQueryService.setHttpRequest(httpRequest);
     }
 
     @Test
-    public void testErQueryUpstream() {
-        erQueryService.setRest(rest);
-        searchOption = SearchOption.UP_STREAM;
-        given(rest.exchange(Mockito.any(URI.class), Mockito.any(HttpMethod.class), Mockito.any(HttpEntity.class),
-                Mockito.any(Class.class))).willAnswer(
-                        returnRestExchange(Mockito.any(URI.class), Mockito.any(HttpMethod.class),
-                                Mockito.any(HttpEntity.class), Mockito.any(Class.class)));
-        ResponseEntity<JsonNode> result = erQueryService.getEventStreamDataById(eventId, searchOption, limitParam,
-                levels, isTree);
+    public void testErQueryUpstream() throws ClientProtocolException, URISyntaxException, IOException {
+//        when(httpExecutor.executeRequest(any(HttpRequestBase.class))).thenAnswer(validateRequest(Mockito.any(HttpRequestBase.class)));
+        BDDMockito.given(httpExecutor.executeRequest(any(HttpRequestBase.class))).willAnswer(validateRequest(Mockito.any(HttpRequestBase.class)));
+        erQueryService.getEventStreamDataById(eventId, searchOption, limitParam, levels, isTree);
     }
 
-    Answer<ResponseEntity> returnRestExchange(URI url, HttpMethod method, HttpEntity<?> requestEntity,
-            Class responseType) {
+    Answer<ResponseEntity> validateRequest(HttpRequestBase httpRequestBase ) {
         return invocation -> {
-            URI arg0 = invocation.getArgument(0);
+            DefaultHttpResponseFactory responseFactory = new DefaultHttpResponseFactory();
+            HttpResponse response = responseFactory.newHttpResponse(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 400, ""), null);
+            HttpPost postRequest = invocation.getArgument(0);
             String expectedUri = buildUri();
-            assertEquals(expectedUri, arg0.toString());
-            HttpEntity arg2 = invocation.getArgument(2);
-            SearchParameters body = (SearchParameters) arg2.getBody();
-            assertBody(body);
-            boolean firstStop = true;
-            return new ResponseEntity(HttpStatus.OK);
+            assertEquals(expectedUri, postRequest.getURI().toString());
+            HttpEntity httpEntity = postRequest.getEntity();
+            InputStream bodyInputStream = httpEntity.getContent();
+            String bodyString = CharStreams.toString(new InputStreamReader(bodyInputStream, Charsets.UTF_8));
+            assertEquals("{\"dlt\":[],\"ult\":[\"ALL\"]}", bodyString);
+            return new ResponseEntity(response);
         };
     }
 
     public String buildUri() {
         String uri = "";
-        uri += erQueryService.getUrl().trim() + eventId + "?limit=" + limitParam + "&levels=" + levels + "&tree="
-                + isTree;
+        uri += erQueryService.getErBaseUrl().trim() + eventId + "?limit=" + limitParam + "&tree=" + isTree + "&levels=" + levels;
         return uri;
     }
-
-    public void assertBody(SearchParameters body) {
-        assertNotNull(body);
-        boolean searchActionIsRight = false;
-        if (searchOption == SearchOption.DOWN_STREAM) {
-            searchActionIsRight = body.getDlt() != null && !body.getDlt().isEmpty();
-        } else if (searchOption == SearchOption.UP_STREAM) {
-            searchActionIsRight = body.getUlt() != null && !body.getUlt().isEmpty();
-        } else if (searchOption == SearchOption.UP_AND_DOWN_STREAM) {
-            searchActionIsRight = body.getDlt() != null && !body.getDlt().isEmpty() && body.getUlt() != null
-                    && !body.getUlt().isEmpty();
-        }
-        assertEquals(searchActionIsRight, true);
-    }
-
-    @Test
-    public void queryParamsTest() throws URISyntaxException {
-        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap(3);
-        expectedQueryParams.add("limit", "10");
-        expectedQueryParams.add("levels", "5");
-        expectedQueryParams.add("tree", "true");
-        UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
-        UriComponents result = builder.queryParams(expectedQueryParams).build();
-        assertEquals("limit=10&levels=5&tree=true", result.getQuery());
-        assertEquals(expectedQueryParams, result.getQueryParams());
-    }
-
-    @Test
-    public void uriParamAndHeaderTest() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addHeader("Forwarded", "proto=https; host=127.0.0.1");
-        request.setScheme("http");
-        request.setServerName("localhost");
-        request.setRequestURI("/search/6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43");
-
-        HttpRequest httpRequest = new ServletServerHttpRequest(request);
-        UriComponents result = UriComponentsBuilder.fromHttpRequest(httpRequest).build();
-
-        assertEquals("https", result.getScheme());
-        assertEquals("127.0.0.1", result.getHost());
-        assertEquals("/search/6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43", result.getPath());
-        assertEquals("https://127.0.0.1/search/6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43", result.toUriString());
-    }
-
 }

--- a/src/test/java/com/ericsson/ei/flowtests/ArrayAggregationTest.java
+++ b/src/test/java/com/ericsson/ei/flowtests/ArrayAggregationTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.http.Header;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -20,8 +21,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestPropertySource;
@@ -33,6 +32,7 @@ import com.ericsson.ei.erqueryservice.ERQueryService;
 import com.ericsson.ei.erqueryservice.SearchOption;
 import com.ericsson.ei.handlers.UpStreamEventsHandler;
 import com.ericsson.ei.utils.TestContextInitializer;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -71,8 +71,9 @@ public class ArrayAggregationTest extends FlowTestBase {
         objectNode.set("upstreamLinkObjects", objectMapper.readTree(upStreamResult));
         objectNode.set("downstreamLinkObjects", objectMapper.createArrayNode());
 
+        Header[] headers = {};
         when(erQueryService.getEventStreamDataById(anyString(), any(SearchOption.class), anyInt(), anyInt(),
-                anyBoolean())).thenReturn(new ResponseEntity<>(objectNode, HttpStatus.OK));
+                anyBoolean())).thenReturn(new ResponseEntity(200, objectNode.toString(), headers));
     }
 
     @Override

--- a/src/test/java/com/ericsson/ei/flowtests/FlowSourceChangeObject.java
+++ b/src/test/java/com/ericsson/ei/flowtests/FlowSourceChangeObject.java
@@ -26,14 +26,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.http.Header;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -43,6 +42,7 @@ import com.ericsson.ei.App;
 import com.ericsson.ei.erqueryservice.ERQueryService;
 import com.ericsson.ei.erqueryservice.SearchOption;
 import com.ericsson.ei.handlers.UpStreamEventsHandler;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -82,8 +82,10 @@ public class FlowSourceChangeObject extends FlowTestBase {
         ObjectNode objectNode = objectMapper.createObjectNode();
         objectNode.set("upstreamLinkObjects", objectMapper.readTree(upStreamResult));
         objectNode.set("downstreamLinkObjects", objectMapper.createArrayNode());
+
+        Header[] headers = {};
         when(erQueryService.getEventStreamDataById(anyString(), any(SearchOption.class), anyInt(), anyInt(),
-                anyBoolean())).thenReturn(new ResponseEntity<>(objectNode, HttpStatus.OK));
+                anyBoolean())).thenReturn(new ResponseEntity(200, objectNode.toString(), headers));
     }
 
     @Override

--- a/src/test/java/com/ericsson/ei/flowtests/FlowTest.java
+++ b/src/test/java/com/ericsson/ei/flowtests/FlowTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.http.Header;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -37,8 +38,6 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestPropertySource;
@@ -50,6 +49,7 @@ import com.ericsson.ei.erqueryservice.ERQueryService;
 import com.ericsson.ei.erqueryservice.SearchOption;
 import com.ericsson.ei.handlers.UpStreamEventsHandler;
 import com.ericsson.ei.utils.TestContextInitializer;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -96,8 +96,9 @@ public class FlowTest extends FlowTestBase {
             objectNode.set("upstreamLinkObjects", upstreamJson);
             objectNode.set("downstreamLinkObjects", objectMapper.createArrayNode());
 
+            Header[] headers = {};
             when(erQueryService.getEventStreamDataById(anyString(), any(SearchOption.class), anyInt(), anyInt(),
-                    anyBoolean())).thenReturn(new ResponseEntity<>(objectNode, HttpStatus.OK));
+                    anyBoolean())).thenReturn(new ResponseEntity(200, objectNode.toString(), headers));
         } else {
             final URL upStreamInput = this.getClass().getClassLoader().getResource(UPSTREAM_INPUT_FILE);
             ArrayNode upstreamJson = (ArrayNode) objectMapper.readTree(upStreamInput);

--- a/src/test/java/com/ericsson/ei/flowtests/TrafficGeneratedTest.java
+++ b/src/test/java/com/ericsson/ei/flowtests/TrafficGeneratedTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.http.Header;
 import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -42,8 +43,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -56,6 +55,7 @@ import com.ericsson.ei.handlers.ObjectHandler;
 import com.ericsson.ei.handlers.RmqHandler;
 import com.ericsson.ei.handlers.UpStreamEventsHandler;
 import com.ericsson.ei.test.utils.TestConfigs;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -107,8 +107,9 @@ public class TrafficGeneratedTest extends FlowTestBase {
         objectNode.set("upstreamLinkObjects", objectMapper.createArrayNode());
         objectNode.set("downstreamLinkObjects", objectMapper.createArrayNode());
 
+        Header[] headers = {};
         when(erQueryService.getEventStreamDataById(anyString(), any(SearchOption.class), anyInt(), anyInt(),
-                anyBoolean())).thenReturn(new ResponseEntity<>(objectNode, HttpStatus.OK));
+                anyBoolean())).thenReturn(new ResponseEntity(200, objectNode.toString(), headers));
     }
 
     @Override

--- a/src/test/java/com/ericsson/ei/handlers/test/UpStreamEventHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/handlers/test/UpStreamEventHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
+import org.apache.http.Header;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -13,8 +14,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -24,6 +23,7 @@ import com.ericsson.ei.erqueryservice.ERQueryService;
 import com.ericsson.ei.erqueryservice.SearchOption;
 import com.ericsson.ei.handlers.UpStreamEventsHandler;
 import com.ericsson.ei.utils.TestContextInitializer;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -52,12 +52,11 @@ public class UpStreamEventHandlerTest {
                 + "\t\t\t{\"_id\":\"event8_level_2\"}]]}\n";
         final JsonNode response = new ObjectMapper().readTree(upStreamString);
 
-        ResponseEntity<JsonNode> upStreamResponse = new ResponseEntity<>(response, HttpStatus.CREATED);
-
         ERQueryService mockedERQueryService = mock(ERQueryService.class);
         String aggregatedObjectId = "0123456789abcdef";
+        Header[] headers = {};
         when(mockedERQueryService.getEventStreamDataById(aggregatedObjectId, SearchOption.UP_STREAM, -1, -1, true))
-                .thenReturn(upStreamResponse);
+                .thenReturn(new ResponseEntity(201, response.toString(), headers));
 
         classUnderTest.runHistoryExtractionRulesOnAllUpstreamEvents("0123456789abcdef");
 


### PR DESCRIPTION
Needs https://github.com/eiffel-community/eiffel-commons/pull/24 merged and released first.
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
closes #299
### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
- Fix bug where the URI to ERQueryService was built up incorrect. Changed the rest template to the HttpRequest in Eiffel commons which handles this as well as cleaner code.
- Fix tests to work correctly with new request library. 

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
Erik Edling erik.edling@ericsson.com