### PR TITLE
Add 2.0.0 versions in compatibility page

### DIFF
--- a/wiki/markdown/compatibility.md
+++ b/wiki/markdown/compatibility.md
@@ -21,7 +21,8 @@ Compatible: ✔️️ Yes
 #### Front-end: 1.x
 Compatible: ❌  No, major Issue
 
-Notes: In Eiffel Intelligence 2.0.0 some new changes were introduced which
+Notes: 
+- In Eiffel Intelligence 2.0.0 some new changes were introduced which
 are not backwards compatible. [See release notes](https://github.com/eiffel-community/eiffel-intelligence-frontend/releases/tag/2.0.0).
 
 ## Back-end: 1.0.2

--- a/wiki/markdown/compatibility.md
+++ b/wiki/markdown/compatibility.md
@@ -1,61 +1,29 @@
 # Compatibility
 
-We recommend using the latest version of back-end and front-end whenever possible. However, this page contains a compatibility matrix and notes when pairing different versions.
+We recommend using the latest version of back-end and front-end whenever 
+possible. However, this page contains a compatibility matrix and notes 
+when pairing different versions.
 
-|                      |Front-end ➡           |                      |                      |                      |
-|---------------------:|:--------------------:|:--------------------:|:--------------------:|:--------------------:|
-|**Back-end ⬇**        |                 1.0.0|                 1.0.1|                 1.0.2|                 1.0.3|
-|[1.0.0](#back-end-100)|[✔️️](#front-end-100)   |[✔️️](#front-end-101)   |[✅](#front-end-102)  |[✅](#front-end-103)  |
-|[1.0.1](#back-end-101)|[✔️️](#front-end-100-1) |[✔️️](#front-end-101-1) |[✅](#front-end-102-1)|[✅](#front-end-103-1)|
-|[1.0.2](#back-end-102)|[❕](#front-end-100-2)|[✅](#front-end-101-2)|[✔️️](#front-end-102-2) |[✔️️](#front-end-103-2) |
+|                      |Front-end ➡           |
+|---------------------:|:--------------------:|
+|**Back-end ⬇**        |Recommended front-end versions  |
+|[2.0.0](#back-end-200)|Front-end 2.0.0 version         |
+|[1.0.2](#back-end-102)|Front-end 1.x versions          |
+|[1.0.1](#back-end-101)|Front-end 1.x versions          |
+|[1.0.0](#back-end-100)|Front-end 1.x versions          |
+
 
 ✔️️ Yes | ✅ Yes, minor Issue | ❕ Yes, medium Issue | ❌ No, major Issue
 
-## Back-end: 1.0.0
-#### Front-end: 1.0.0
+## Back-end: 2.0.0
+#### Front-end: 2.0.0
 Compatible: ✔️️ Yes
 
-Notes: -
+#### Front-end: 1.x
+Compatible: ❌  No, major Issue
 
-#### Front-end: 1.0.1
-Compatible: ✔️️ Yes
-
-Notes: -
-
-#### Front-end: 1.0.2
-Compatible: ✅ Yes, minor Issue
-
-Notes:
-- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
-
-#### Front-end: 1.0.3
-Compatible: ✅ Yes, minor Issue
-
-Notes:
-- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
-
-## Back-end: 1.0.1
-#### Front-end: 1.0.0
-Compatible: ✔️️ Yes
-
-Notes: -
-
-#### Front-end: 1.0.1
-Compatible: ✔️️ Yes
-
-Notes: -
-
-#### Front-end: 1.0.2
-Compatible: ✅ Yes, minor Issue
-
-Notes:
-- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
-
-#### Front-end: 1.0.3
-Compatible: ✅ Yes, minor Issue
-
-Notes:
-- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
+Notes: In Eiffel Intelligence 2.0.0 some new changes were introduced which
+are not backwards compatible. [See release notes](https://github.com/eiffel-community/eiffel-intelligence-frontend/releases/tag/2.0.0).
 
 ## Back-end: 1.0.2
 #### Front-end: 1.0.0
@@ -80,3 +48,49 @@ Notes: -
 Compatible: ✔️️ Yes
 
 Notes: -
+
+## Back-end: 1.0.1
+#### Front-end: 1.0.0
+Compatible: ✔️️ Yes
+
+Notes: -
+
+#### Front-end: 1.0.1
+Compatible: ✔️️ Yes
+
+Notes: -
+
+#### Front-end: 1.0.2
+Compatible: ✅ Yes, minor Issue
+
+Notes:
+- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
+
+#### Front-end: 1.0.3
+Compatible: ✅ Yes, minor Issue
+
+Notes:
+- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
+
+## Back-end: 1.0.0
+#### Front-end: 1.0.0
+Compatible: ✔️️ Yes
+
+Notes: -
+
+#### Front-end: 1.0.1
+Compatible: ✔️️ Yes
+
+Notes: -
+
+#### Front-end: 1.0.2
+Compatible: ✅ Yes, minor Issue
+
+Notes:
+- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
+
+#### Front-end: 1.0.3
+Compatible: ✅ Yes, minor Issue
+
+Notes:
+- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.

--- a/wiki/markdown/compatibility.md
+++ b/wiki/markdown/compatibility.md
@@ -1,8 +1,8 @@
 # Compatibility
 
 We recommend using the latest version of back-end and front-end whenever 
-possible. However, this page contains a compatibility matrix and notes 
-when pairing different versions.
+possible. If you are interested in using an older version, see the below 
+table to see which versions are compatible with each other. 
 
 |Back-end              |Recommended front-end versions  |
 |:--------------------:|:------------------------------:|
@@ -35,13 +35,13 @@ Compatible: ✔️️ Yes
 Notes: -
 
 #### Front-end: 1.0.1
-Compatible: ✅ Yes
+Compatible: Works, but not recommended
 
 Notes:
 - Documentation is based on the [Toulouse](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to gav package instead of purl does not change subscription structure.
 
 #### Front-end: 1.0.0
-Compatible: ❕ Yes
+Compatible: Works, but not recommended
 
 Notes:
 - Documentation is based on the [Toulouse](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to gav package instead of purl does not change subscription structure.
@@ -49,13 +49,13 @@ Notes:
 
 ## Back-end: 1.0.1
 #### Front-end: 1.0.3
-Compatible: ✅ Yes
+Compatible: Works, but not recommended
 
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
 
 #### Front-end: 1.0.2
-Compatible: ✅ Yes 
+Compatible: Works, but not recommended
 
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
@@ -72,13 +72,13 @@ Notes: -
 
 ## Back-end: 1.0.0
 #### Front-end: 1.0.3
-Compatible: ✅ Yes
+Compatible: Works, but not recommended
 
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
 
 #### Front-end: 1.0.2
-Compatible: ✅ Yes
+Compatible: Works, but not recommended
 
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.

--- a/wiki/markdown/compatibility.md
+++ b/wiki/markdown/compatibility.md
@@ -4,14 +4,13 @@ We recommend using the latest version of back-end and front-end whenever
 possible. However, this page contains a compatibility matrix and notes 
 when pairing different versions.
 
-|                      |Front-end ➡           |
-|---------------------:|:--------------------:|
-|**Back-end ⬇**        |Recommended front-end versions  |
+|                      |Recommended front-end versions  |
+|---------------------:|:------------------------------:|
+|**Back-end ⬇**        |                                |
 |[2.0.0](#back-end-200)|Front-end 2.0.0 version         |
 |[1.0.2](#back-end-102)|Front-end 1.x versions          |
 |[1.0.1](#back-end-101)|Front-end 1.x versions          |
 |[1.0.0](#back-end-100)|Front-end 1.x versions          |
-
 
 ✔️️ Yes | ✅ Yes, minor Issue | ❕ Yes, medium Issue | ❌ No, major Issue
 

--- a/wiki/markdown/compatibility.md
+++ b/wiki/markdown/compatibility.md
@@ -4,28 +4,42 @@ We recommend using the latest version of back-end and front-end whenever
 possible. However, this page contains a compatibility matrix and notes 
 when pairing different versions.
 
-|                      |Recommended front-end versions  |
-|---------------------:|:------------------------------:|
-|**Back-end ⬇**        |                                |
-|[2.0.0](#back-end-200)|Front-end 2.0.0 version         |
-|[1.0.2](#back-end-102)|Front-end 1.x versions          |
-|[1.0.1](#back-end-101)|Front-end 1.x versions          |
-|[1.0.0](#back-end-100)|Front-end 1.x versions          |
-
-✔️️ Yes | ✅ Yes, minor Issue | ❕ Yes, medium Issue | ❌ No, major Issue
+|Back-end              |Recommended front-end versions  |
+|:--------------------:|:------------------------------:|
+|[2.0.0](#back-end-200)|Front-end 2.0.0                 |
+|[1.0.2](#back-end-102)|Front-end 1.0.3                 |
+|[1.0.1](#back-end-101)|Front-end 1.0.1                 |
+|[1.0.0](#back-end-100)|Front-end 1.0.1                 |
 
 ## Back-end: 2.0.0
 #### Front-end: 2.0.0
 Compatible: ✔️️ Yes
 
 #### Front-end: 1.x
-Compatible: ❌  No, major Issue
+Compatible: ❌  No
 
 Notes: 
 - In Eiffel Intelligence 2.0.0 some new changes were introduced which
 are not backwards compatible. [See release notes](https://github.com/eiffel-community/eiffel-intelligence-frontend/releases/tag/2.0.0).
 
 ## Back-end: 1.0.2
+
+#### Front-end: 1.0.3
+Compatible: ✔️️ Yes
+
+Notes: -
+
+#### Front-end: 1.0.2
+Compatible: ✔️️ Yes
+
+Notes: -
+
+#### Front-end: 1.0.1
+Compatible: ✅ Yes, minor Issue
+
+Notes:
+- Documentation is based on the [Toulouse](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to gav package instead of purl does not change subscription structure.
+
 #### Front-end: 1.0.0
 Compatible: ❕ Yes, medium Issue
 
@@ -33,55 +47,35 @@ Notes:
 - Documentation is based on the [Toulouse](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to gav package instead of purl does not change subscription structure.
 - Multiple e-mail recipients are not supported through the front-end subscription form. This becomes possible to do from front-end version [1.0.1](https://github.com/eiffel-community/eiffel-intelligence-frontend/releases/tag/1.0.1) and forward.
 
-#### Front-end: 1.0.1
+## Back-end: 1.0.1
+#### Front-end: 1.0.3
 Compatible: ✅ Yes, minor Issue
 
 Notes:
-- Documentation is based on the [Toulouse](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to gav package instead of purl does not change subscription structure.
+- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
 
 #### Front-end: 1.0.2
+Compatible: ✅ Yes, minor Issue
+
+Notes:
+- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
+
+#### Front-end: 1.0.1
 Compatible: ✔️️ Yes
 
 Notes: -
 
-#### Front-end: 1.0.3
-Compatible: ✔️️ Yes
-
-Notes: -
-
-## Back-end: 1.0.1
 #### Front-end: 1.0.0
 Compatible: ✔️️ Yes
 
 Notes: -
-
-#### Front-end: 1.0.1
-Compatible: ✔️️ Yes
-
-Notes: -
-
-#### Front-end: 1.0.2
-Compatible: ✅ Yes, minor Issue
-
-Notes:
-- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
-
-#### Front-end: 1.0.3
-Compatible: ✅ Yes, minor Issue
-
-Notes:
-- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
 
 ## Back-end: 1.0.0
-#### Front-end: 1.0.0
-Compatible: ✔️️ Yes
+#### Front-end: 1.0.3
+Compatible: ✅ Yes, minor Issue
 
-Notes: -
-
-#### Front-end: 1.0.1
-Compatible: ✔️️ Yes
-
-Notes: -
+Notes:
+- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
 
 #### Front-end: 1.0.2
 Compatible: ✅ Yes, minor Issue
@@ -89,8 +83,12 @@ Compatible: ✅ Yes, minor Issue
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
 
-#### Front-end: 1.0.3
-Compatible: ✅ Yes, minor Issue
+#### Front-end: 1.0.1
+Compatible: ✔️️ Yes
 
-Notes:
-- Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
+Notes: -
+
+#### Front-end: 1.0.0
+Compatible: ✔️️ Yes
+
+Notes: -

--- a/wiki/markdown/compatibility.md
+++ b/wiki/markdown/compatibility.md
@@ -35,13 +35,13 @@ Compatible: ✔️️ Yes
 Notes: -
 
 #### Front-end: 1.0.1
-Compatible: ✅ Yes, minor Issue
+Compatible: ✅ Yes
 
 Notes:
 - Documentation is based on the [Toulouse](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to gav package instead of purl does not change subscription structure.
 
 #### Front-end: 1.0.0
-Compatible: ❕ Yes, medium Issue
+Compatible: ❕ Yes
 
 Notes:
 - Documentation is based on the [Toulouse](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to gav package instead of purl does not change subscription structure.
@@ -49,13 +49,13 @@ Notes:
 
 ## Back-end: 1.0.1
 #### Front-end: 1.0.3
-Compatible: ✅ Yes, minor Issue
+Compatible: ✅ Yes
 
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
 
 #### Front-end: 1.0.2
-Compatible: ✅ Yes, minor Issue
+Compatible: ✅ Yes 
 
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
@@ -72,13 +72,13 @@ Notes: -
 
 ## Back-end: 1.0.0
 #### Front-end: 1.0.3
-Compatible: ✅ Yes, minor Issue
+Compatible: ✅ Yes
 
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.
 
 #### Front-end: 1.0.2
-Compatible: ✅ Yes, minor Issue
+Compatible: ✅ Yes
 
 Notes:
 - Documentation is based on the [Agen](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md#versioning) version of the Eiffel protocol but it’s still functional since the jmespath reference to purl package instead of gav does not change subscription structure.


### PR DESCRIPTION

### Applicable Issues
Latest release, 2.0.0 was not included in compatibility page.

### Description of the Change
Reordered the page so latest releases are on the top of the page. The 2.0.0 release is not backwards compatible with older 1.x versions. Linked to release notes of 2.0.0 release.

Changed the table to be more maintainable in the future, keeping a list of which front-ends are compatible with which back-ends. Keeping the older 1.x versions for now, but for future releases we might want to trim this list a bit.

### Benefits
Latest versions available on this page.


### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
