### PR TITLE
Failed notifications object now stores error message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <forkCount>3</forkCount>
+                    <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <skipTests>${skipTests}</skipTests>
                     <skipITs>${skipITs}</skipITs>

--- a/src/functionaltests/java/com/ericsson/ei/query/QueryAggregatedObjectsTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/query/QueryAggregatedObjectsTestSteps.java
@@ -293,36 +293,6 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
 
     }
 
-    @And("^Check missed notification has been returned$")
-    public void check_missed_notification_has_been_returned() throws Throwable {
-        final String expectedResponse = "{\"queryResponseEntity\":{}}";
-        final String subscriptionName = "Subscription_1";
-        final String entryPoint = "/queryMissedNotifications";
-
-        LOGGER.debug("Trying to query /queryMissedNotifications RestApi one more time with subscriptionName: "
-                + subscriptionName);
-
-        HttpRequest getRequest = new HttpRequest(HttpMethod.GET);
-        response = getRequest.setPort(applicationPort)
-                             .setHost(hostName)
-                             .addHeader("content-type", "application/json")
-                             .addHeader("Accept", "application/json")
-                             .setEndpoint(entryPoint)
-                             .addParam("subscriptionName", subscriptionName)
-                             .performRequest();
-
-        String responseAsString = response.getBody().toString();
-        int responseStatusCode = response.getStatusCodeValue();
-        LOGGER.debug("Response of /queryMissedNotifications RestApi, Status Code: " + responseStatusCode
-                + "\nResponse: " + responseAsString);
-
-        assertEquals(HttpStatus.OK.value(), responseStatusCode);
-        assertEquals(
-                "Differences between actual Missed Notification response:\n" + responseAsString
-                        + "\nand expected  Missed Notification response:\n" + expectedResponse,
-                expectedResponse, responseAsString);
-    }
-
     @And("^Perform a query on created Aggregated object with filter$")
     public void perform_valid_query_and_filter_on_aggregated_object() throws Throwable {
         final String expectedResponse = "[{\"6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43\":\"\\\"33d05e6f-9bd9-4138-83b6-e20cc74680a3\\\"\"}]";

--- a/src/functionaltests/java/com/ericsson/ei/query/QueryAggregatedObjectsTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/query/QueryAggregatedObjectsTestSteps.java
@@ -269,7 +269,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                              .addHeader("content-type", "application/json")
                              .addHeader("Accept", "application/json")
                              .setEndpoint(entryPoint)
-                             .addParam("SubscriptionName", subscriptionName)
+                             .addParam("subscriptionName", subscriptionName)
                              .performRequest();
 
         String responseAsString = response.getBody().toString();
@@ -278,8 +278,9 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                 + "\nResponse: " + responseAsString);
 
         JsonNode jsonNodeResult = objMapper.readValue(response.getBody().toString(), JsonNode.class);
+        String test = response.getBody().toString();
         String actualTestCaseStartedEventId = jsonNodeResult.get("queryResponseEntity")
-                                                            .get("AggregatedObject")
+                                                            .get("aggregatedObject")
                                                             .get("testCaseExecutions")
                                                             .get(0)
                                                             .get("testCaseStartedEventId")
@@ -307,7 +308,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                              .addHeader("content-type", "application/json")
                              .addHeader("Accept", "application/json")
                              .setEndpoint(entryPoint)
-                             .addParam("SubscriptionName", subscriptionName)
+                             .addParam("subscriptionName", subscriptionName)
                              .performRequest();
 
         String responseAsString = response.getBody().toString();

--- a/src/functionaltests/resources/features/queryAggregatedObjects.feature
+++ b/src/functionaltests/resources/features/queryAggregatedObjects.feature
@@ -10,7 +10,6 @@ Feature: Test Query Aggregated Objects
     And Perform several valid freestyle queries on created Aggregated objects
     And Perform an invalid freestyle query on Aggregated object
     And Perform a query for missed notification
-    And Check missed notification has been returned
     And Perform a query on created Aggregated object with filter
     And Perform a query and filter with part of path
 

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/FlowStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/FlowStepsIT.java
@@ -150,7 +150,6 @@ public class FlowStepsIT extends IntegrationTestBase {
     public void rest_post_body_media_type_is_set_to_is_set_in_subscription(
             String restPostBodyMediaType) throws Throwable {
         subscriptionObject.setRestPostBodyMediaType(restPostBodyMediaType);
-
     }
 
     @When("^parameter form key \"([^\"]*)\" and form value \"([^\"]*)\" is added in subscription$")

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/FlowStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/FlowStepsIT.java
@@ -9,6 +9,8 @@ import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -313,6 +315,21 @@ public class FlowStepsIT extends IntegrationTestBase {
     @Override
     protected int extraEventsCount() {
         return extraEventsCount;
+    }
+
+    @Override
+    protected List<String> getEventNamesToSend() throws IOException {
+        ArrayList<String> eventNames = new ArrayList<>();
+
+        URL eventsInput = new File(getEventsFilePath()).toURI().toURL();
+        Iterator eventsIterator = objectMapper.readTree(eventsInput).fields();
+
+        while (eventsIterator.hasNext()) {
+            Map.Entry pair = (Map.Entry) eventsIterator.next();
+            eventNames.add(pair.getKey().toString());
+        }
+
+        return eventNames;
     }
 
     /**

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/ArtifactFlowRunnerIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/ArtifactFlowRunnerIT.java
@@ -1,4 +1,4 @@
-package com.ericsson.ei.integrationtests;
+package com.ericsson.ei.integrationtests.flow;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -8,7 +8,7 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "src/integrationtests/resources/features/ArtifactFlowIT.feature", glue = {
-        "com.ericsson.ei.integrationtests" }, plugin = { "pretty",
+        "com.ericsson.ei.integrationtests.flow" }, plugin = { "pretty",
                 "html:target/cucumber-reports/ArtifactFlowRunnerIT"})
 public class ArtifactFlowRunnerIT {
     @BeforeClass

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
@@ -1,4 +1,4 @@
-package com.ericsson.ei.integrationtests;
+package com.ericsson.ei.integrationtests.flow;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
@@ -84,22 +84,22 @@ public class FlowStepsIT extends IntegrationTestBase {
     private JSONObject jobStatusData;
 
     @Given("^the rules \"([^\"]*)\"$")
-    public void the_rules(String rulesFilePath) throws Throwable {
+    public void rules(String rulesFilePath) throws Throwable {
         this.rulesFilePath = rulesFilePath;
     }
 
     @Given("^the events \"([^\"]*)\"$")
-    public void the_events(String eventsFilePath) throws Throwable {
+    public void events(String eventsFilePath) throws Throwable {
         this.eventsFilePath = eventsFilePath;
     }
 
     @Given("^the resulting aggregated object \"([^\"]*)\";$")
-    public void the_resulting_aggregated_object(String aggregatedObjectFilePath) throws Throwable {
+    public void resultingAggregatedObject(String aggregatedObjectFilePath) throws Throwable {
         this.aggregatedObjectFilePath = aggregatedObjectFilePath;
     }
 
     @Given("^the upstream input \"([^\"]*)\"$")
-    public void the_upstream_input(String upstreamInputFile) throws Throwable {
+    public void upstreamInput(String upstreamInputFile) throws Throwable {
         this.upstreamInputFile = upstreamInputFile;
 
         final URL upStreamInput = new File(upstreamInputFile).toURI().toURL();
@@ -108,12 +108,12 @@ public class FlowStepsIT extends IntegrationTestBase {
     }
 
     @Given("^jenkins data is prepared$")
-    public void jenkins_data_is_prepared() throws Throwable {
+    public void jenkinsDataIsPrepared() throws Throwable {
         jenkinsXmlData = new JenkinsXmlData();
     }
 
     @Given("^subscription object of type \"([^\"]*)\" with name \"([^\"]*)\" is created$")
-    public void subscription_object_for_with_name_is_created(String subscriptionType,
+    public void subscriptionObjectOfTypeIsCreated(String subscriptionType,
             String subscriptionName) throws Throwable {
         if (subscriptionType.equalsIgnoreCase("Mail")) {
             subscriptionObject = new MailSubscriptionObject(subscriptionName);
@@ -123,13 +123,13 @@ public class FlowStepsIT extends IntegrationTestBase {
     }
 
     @When("^notification meta \"([^\"]*)\" is set in subscription$")
-    public void notification_meta_is_set_in_subscription(String notificationMeta) throws Throwable {
+    public void notificationMetaIsSetInSubscription(String notificationMeta) throws Throwable {
         notificationMeta = replaceVariablesInNotificationMeta(notificationMeta);
         subscriptionObject.setNotificationMeta(notificationMeta);
     }
 
     @When("^\"([^\"]*)\" authentication with username \"([^\"]*)\" and password \"([^\"]*)\" is set in subscription$")
-    public void basic_auth_authentication_with_username_and_password_is_set_in_subscription(
+    public void authenticationWithUsernameAndPasswordIsSetInSubscription(
             String authenticationType, String username, String password) throws Throwable {
 
         RestPostSubscriptionObject restPostSubscriptionObject = (RestPostSubscriptionObject) subscriptionObject;
@@ -142,30 +142,30 @@ public class FlowStepsIT extends IntegrationTestBase {
     }
 
     @When("^rest post body media type is set to \"([^\"]*)\" is set in subscription$")
-    public void rest_post_body_media_type_is_set_in_subscription(
+    public void restPostBodyMediaTypeIsSetInSubscription(
             String restPostBodyMediaType) throws Throwable {
         subscriptionObject.setRestPostBodyMediaType(restPostBodyMediaType);
     }
 
     @When("^parameter form key \"([^\"]*)\" and form value \"([^\"]*)\" is added in subscription$")
-    public void parameter_key_and_value_is_added_in_subscription(String formKey, String formValue) {
+    public void parameterKeyAndValueIsAddedInSubscription(String formKey, String formValue) {
         subscriptionObject.addNotificationMessageKeyValue(formKey, formValue);
     }
 
     @When("^condition \"([^\"]*)\" at requirement index '(\\d+)' is added in subscription$")
-    public void requirement_for_condition_is_added_in_subscription(String condition,
+    public void conditionOrRequirementIsAddedInSubscription(String condition,
             int requirementIndex) throws Throwable {
         subscriptionObject.addConditionToRequirement(requirementIndex, new JSONObject().put(
                 "jmespath", condition));
     }
 
     @When("^the eiffel events are sent$")
-    public void eiffel_events_are_sent() throws Throwable {
+    public void eiffelEventsAreSent() throws Throwable {
         super.sendEventsAndConfirm();
     }
 
     @When("^the upstream input events are sent")
-    public void upstream_input_events_are_sent() throws IOException {
+    public void upstreamInputEventsAreSent() throws IOException {
         final URL upStreamInput = new File(upstreamInputFile).toURI().toURL();
         ArrayNode upstreamJson = (ArrayNode) objectMapper.readTree(upStreamInput);
         if (upstreamJson != null) {
@@ -177,23 +177,23 @@ public class FlowStepsIT extends IntegrationTestBase {
     }
 
     @When("^job token \"([^\"]*)\" is added to jenkins data$")
-    public void token_is_added_to_jenkins_data(String token) throws Throwable {
+    public void tokenIsAddedToJenkinsData(String token) throws Throwable {
         jenkinsXmlData.addJobToken(token);
         jenkinsJobToken = token;
     }
 
     @When("^parameter key \"([^\"]*)\" is added to jenkins data$")
-    public void parameter_key_and_value_is_added_to_jenkins_data(String key) throws Throwable {
+    public void parameterKeyAndValueIsAddedToJenkinsData(String key) throws Throwable {
         jenkinsXmlData.addBuildParameter(key);
     }
 
     @When("^bash script \"([^\"]*)\" is added to jenkins data$")
-    public void script_is_added_to_jenkins_data(String bashScript) throws Throwable {
+    public void scriptIsAddedToJenkinsData(String bashScript) throws Throwable {
         jenkinsXmlData.addBashScript(bashScript);
     }
 
     @When("^jenkins job status data fetched$")
-    public void the_jenkins_job_should_have_been_triggered() throws Throwable {
+    public void jenkinsJobStatusDataFetched() throws Throwable {
         Boolean jobStatusDataFetched = false;
         long stopTime = System.currentTimeMillis() + 30000;
         while (jobStatusDataFetched == false && stopTime > System.currentTimeMillis()) {
@@ -213,30 +213,30 @@ public class FlowStepsIT extends IntegrationTestBase {
     }
 
     @Then("^the expected aggregated object ID is \"([^\"]*)\"$")
-    public void the_expected_aggregated_object_ID_is(String aggregatedObjectID) throws Throwable {
+    public void expectedAggregatedObjectID(String aggregatedObjectID) throws Throwable {
         this.aggregatedObjectID = aggregatedObjectID;
     }
 
     @Then("^verify jenkins job data timestamp is after test subscription was created$")
-    public void verify_jenkins_job_data_timestamp_is_after_test_subscription_was_created()
+    public void verifyJenkinsJobDataTimestampIsAfterTestSubscriptionWasCreated()
             throws Throwable {
         long jenkinsTriggeredTime = jobStatusData.getLong("timestamp");
         assert (jenkinsTriggeredTime >= startTime) : "Jenkins job was triggered before execution of this test.";
     }
 
     @Then("^jenkins job status data has key \"([^\"]*)\" with value \"([^\"]*)\"$")
-    public void jenkins_job_status_data_has_key(String key, String value) throws Throwable {
+    public void jenkinsJobStatusDataHasKey(String key, String value) throws Throwable {
         String extractedValue = extractValueForKeyInJobData(key);
         assertEquals("The data jenkins recieved is not what was expected.", value, extractedValue);
     }
 
     @Then("^the jenkins job should be deleted$")
-    public void the_jenkins_job_should_be_deleted() throws Throwable {
+    public void jenkinsJobShouldBeDeleted() throws Throwable {
         jenkinsManager.deleteJob(this.jenkinsJobName);
     }
 
     @Then("^mongodb should contain \"([^\"]*)\" mails\\.$")
-    public void mongodb_should_contain_mails(int amountOfMails) throws Exception {
+    public void mongodbShouldContainMails(int amountOfMails) throws Exception {
         long stopTime = System.currentTimeMillis() + 30000;
         Boolean mailHasBeenDelivered = false;
         long createdDateInMillis = 0;
@@ -263,7 +263,7 @@ public class FlowStepsIT extends IntegrationTestBase {
     }
 
     @Then("^jenkins is set up with job name \"([^\"]*)\"$")
-    public void jenkins_is_set_up_with_job_name(String JobName) throws Throwable {
+    public void jenkinsIsSetUpWithJobName(String JobName) throws Throwable {
         jenkinsManager = new JenkinsManager(jenkinsProtocol, jenkinsHost, jenkinsPort,
                 jenkinsUsername, jenkinsPassword);
         jenkinsManager.forceCreateJob(JobName, jenkinsXmlData.getXmlAsString());
@@ -271,7 +271,7 @@ public class FlowStepsIT extends IntegrationTestBase {
     }
 
     @Then("^subscription is uploaded$")
-    public void subscription_is_uploaded() throws URISyntaxException {
+    public void subscriptionIsUploaded() throws URISyntaxException {
         assert (subscriptionObject instanceof RestPostSubscriptionObject
                 || subscriptionObject instanceof MailSubscriptionObject) : "SubscriptionObject must have been initiated.";
 

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
@@ -142,7 +142,7 @@ public class FlowStepsIT extends IntegrationTestBase {
     }
 
     @When("^rest post body media type is set to \"([^\"]*)\" is set in subscription$")
-    public void rest_post_body_media_type_is_set_to_is_set_in_subscription(
+    public void rest_post_body_media_type_is_set_in_subscription(
             String restPostBodyMediaType) throws Throwable {
         subscriptionObject.setRestPostBodyMediaType(restPostBodyMediaType);
     }

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
@@ -112,7 +112,7 @@ public class FlowStepsIT extends IntegrationTestBase {
         jenkinsXmlData = new JenkinsXmlData();
     }
 
-    @Given("^subscription object for \"([^\"]*)\" with name \"([^\"]*)\" is created$")
+    @Given("^subscription object of type \"([^\"]*)\" with name \"([^\"]*)\" is created$")
     public void subscription_object_for_with_name_is_created(String subscriptionType,
             String subscriptionName) throws Throwable {
         if (subscriptionType.equalsIgnoreCase("Mail")) {
@@ -120,11 +120,6 @@ public class FlowStepsIT extends IntegrationTestBase {
         } else {
             subscriptionObject = new RestPostSubscriptionObject(subscriptionName);
         }
-    }
-
-    @Given("^all previous steps passed$")
-    public void all_previous_steps_passed() throws Throwable {
-        // Write code here that turns the phrase above into concrete actions
     }
 
     @When("^notification meta \"([^\"]*)\" is set in subscription$")

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
@@ -124,8 +124,8 @@ public class FlowStepsIT extends IntegrationTestBase {
 
     @When("^notification meta \"([^\"]*)\" is set in subscription$")
     public void notificationMetaIsSetInSubscription(String notificationMeta) throws Throwable {
-        notificationMeta = replaceVariablesInNotificationMeta(notificationMeta);
-        subscriptionObject.setNotificationMeta(notificationMeta);
+        String notificationMetaReplaced = replaceVariablesInNotificationMeta(notificationMeta);
+        subscriptionObject.setNotificationMeta(notificationMetaReplaced);
     }
 
     @When("^\"([^\"]*)\" authentication with username \"([^\"]*)\" and password \"([^\"]*)\" is set in subscription$")

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/SourceChangeFlowRunnerIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/SourceChangeFlowRunnerIT.java
@@ -1,4 +1,4 @@
-package com.ericsson.ei.integrationtests;
+package com.ericsson.ei.integrationtests.flow;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -8,7 +8,7 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "src/integrationtests/resources/features/SourceChangeFlowIT.feature", glue = {
-        "com.ericsson.ei.integrationtests" }, plugin = { "pretty",
+        "com.ericsson.ei.integrationtests.flow" }, plugin = { "pretty",
                 "html:target/cucumber-reports/SourceChangeFlowRunnerIT" })
 public class SourceChangeFlowRunnerIT {
     @BeforeClass

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/TestExecutionRunnerIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/TestExecutionRunnerIT.java
@@ -1,4 +1,4 @@
-package com.ericsson.ei.integrationtests;
+package com.ericsson.ei.integrationtests.flow;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -8,7 +8,7 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "src/integrationtests/resources/features/TestExecutionFlowIT.feature", glue = {
-        "com.ericsson.ei.integrationtests" }, plugin = { "pretty",
+        "com.ericsson.ei.integrationtests.flow" }, plugin = { "pretty",
                 "html:target/cucumber-reports/TestExecutionFlowRunnerIT" })
 public class TestExecutionRunnerIT {
     @BeforeClass

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationRunnerIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationRunnerIT.java
@@ -13,16 +13,16 @@ import cucumber.api.junit.Cucumber;
 public class FailedNotificationRunnerIT {
     @BeforeClass
     public static void before() {
-        System.setProperty("aggregated.collection.name", "aggregated_objects_artifact_flow");
-        System.setProperty("waitlist.collection.name", "wait_list_artifact_flow");
-        System.setProperty("subscription.collection.name", "subscription_artifact_flow");
-        System.setProperty("event_object_map.collection.name", "event_object_map_artifact_flow");
+        System.setProperty("aggregated.collection.name", "failed_notification");
+        System.setProperty("waitlist.collection.name", "wait_list_failed_notification");
+        System.setProperty("subscription.collection.name", "subscription_failed_notification");
+        System.setProperty("event_object_map.collection.name", "event_object_map_failed_notification");
         System.setProperty("subscription.collection.repeatFlagHandlerName",
-                "subscription_repeat_handler_artifact_flow");
-        System.setProperty("missedNotificationCollectionName", "missed_notification_artifact_flow");
-        System.setProperty("sessions.collection.name", "sessions_artifact_flow");
+                "subscription_repeat_handler_failed_notification");
+        System.setProperty("missedNotificationCollectionName", "missed_notification_failed_notification");
+        System.setProperty("sessions.collection.name", "sessions_failed_notification");
 
         System.setProperty("rules.path", "/rules/ArtifactRules-Eiffel-Agen-Version.json");
-        System.setProperty("rabbitmq.consumerName", "artifact_queue");
+        System.setProperty("rabbitmq.consumerName", "failed_notification_queue");
     }
 }

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationRunnerIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationRunnerIT.java
@@ -1,0 +1,28 @@
+package com.ericsson.ei.integrationtests.notification;
+
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "src/integrationtests/resources/features/FailedNotificationIT.feature", glue = {
+        "com.ericsson.ei.integrationtests.notification" }, plugin = { "pretty",
+                "html:target/cucumber-reports/FailedNotificationRunnerIT" })
+public class FailedNotificationRunnerIT {
+    @BeforeClass
+    public static void before() {
+        System.setProperty("aggregated.collection.name", "aggregated_objects_artifact_flow");
+        System.setProperty("waitlist.collection.name", "wait_list_artifact_flow");
+        System.setProperty("subscription.collection.name", "subscription_artifact_flow");
+        System.setProperty("event_object_map.collection.name", "event_object_map_artifact_flow");
+        System.setProperty("subscription.collection.repeatFlagHandlerName",
+                "subscription_repeat_handler_artifact_flow");
+        System.setProperty("missedNotificationCollectionName", "missed_notification_artifact_flow");
+        System.setProperty("sessions.collection.name", "sessions_artifact_flow");
+
+        System.setProperty("rules.path", "/rules/ArtifactRules-Eiffel-Agen-Version.json");
+        System.setProperty("rabbitmq.consumerName", "artifact_queue");
+    }
+}

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationRunnerIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationRunnerIT.java
@@ -13,7 +13,7 @@ import cucumber.api.junit.Cucumber;
 public class FailedNotificationRunnerIT {
     @BeforeClass
     public static void before() {
-        System.setProperty("aggregated.collection.name", "failed_notification");
+        System.setProperty("aggregated.collection.name", "aggregated_failed_notification");
         System.setProperty("waitlist.collection.name", "wait_list_failed_notification");
         System.setProperty("subscription.collection.name", "subscription_failed_notification");
         System.setProperty("event_object_map.collection.name", "event_object_map_failed_notification");

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -44,29 +44,12 @@ import util.IntegrationTestBase;
 @TestExecutionListeners(listeners = { DependencyInjectionTestExecutionListener.class })
 @TestPropertySource(properties = { "spring.mail.port: 9999" })
 public class FailedNotificationStepsIT extends IntegrationTestBase {
-    private String jenkinsJobName;
-    private String jenkinsJobToken;
     private String rulesFilePath;
     private String eventsFilePath;
     private ObjectMapper objectMapper = new ObjectMapper();
     private int extraEventsCount = 0;
 
     private long startTime;
-
-    @Value("${jenkins.host:http}")
-    private String jenkinsProtocol;
-
-    @Value("${jenkins.host:localhost}")
-    private String jenkinsHost;
-
-    @Value("${jenkins.port:8082}")
-    private int jenkinsPort;
-
-    @Value("${jenkins.username:admin}")
-    private String jenkinsUsername;
-
-    @Value("${jenkins.password:admin}")
-    private String jenkinsPassword;
 
     private SubscriptionObject subscriptionObject;
 
@@ -92,7 +75,6 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
 
     @When("^notification meta \"([^\"]*)\" is set in subscription$")
     public void notification_meta_is_set_in_subscription(String notificationMeta) throws Throwable {
-        notificationMeta = replaceVariablesInNotificationMeta(notificationMeta);
         subscriptionObject.setNotificationMeta(notificationMeta);
     }
 
@@ -177,32 +159,5 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
         eventNames.add("event_EiffelArtifactCreatedEvent_3");
         eventNames.add("event_EiffelTestCaseTriggeredEvent_3");
         return eventNames;
-    }
-
-    /**
-     * Replaces given input parameters if user wishes with test defined parameters. If user want the
-     * user may specify the host, port job name and token directly in the feauture file and they
-     * will not be replaced.
-     * <p>
-     * ${jenkinsHost} is replaced with jenkins host.
-     * <p>
-     * ${jenkinsPort} is replaced with jenkins port.
-     * <p>
-     * ${jenkinsJobName} is replaced with lastcreated jenkins job name if any.
-     * <p>
-     * ${jenkinsJobToken} is replaced with last created jenkins job token if any.
-     *
-     * @param notificationMeta
-     * @return
-     */
-    private String replaceVariablesInNotificationMeta(String notificationMeta) {
-        notificationMeta = notificationMeta.replaceAll("\\$\\{jenkinsHost\\}", jenkinsHost);
-        notificationMeta = notificationMeta.replaceAll("\\$\\{jenkinsPort\\}", String.valueOf(
-                jenkinsPort));
-        notificationMeta = notificationMeta.replaceAll("\\$\\{jenkinsJobName\\}",
-                this.jenkinsJobName);
-        notificationMeta = notificationMeta.replaceAll("\\$\\{jenkinsJobToken\\}",
-                this.jenkinsJobToken);
-        return notificationMeta;
     }
 }

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -95,7 +95,7 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
     }
 
     @When("^rest post body media type is set to \"([^\"]*)\" is set in subscription$")
-    public void rest_post_body_media_type_is_set_to_is_set_in_subscription(
+    public void rest_post_body_media_type_is_set_in_subscription(
             String restPostBodyMediaType) throws Throwable {
         subscriptionObject.setRestPostBodyMediaType(restPostBodyMediaType);
     }

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -127,9 +127,6 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
                .addParam("subscriptionName", subscriptionName);
         
         ResponseEntity response = request.performRequest();
-        System.out.println("###############################################");
-        System.out.println(response.getBody());
-        System.out.println("###############################################");
         String message = objectMapper.readTree(response.getBody()).get("queryResponseEntity").get("message").toString();
         assertEquals(true, message.contains(searchValue));
     }

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -80,7 +80,7 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
         this.eventsFilePath = eventsFilePath;
     }
 
-    @Given("^subscription object for \"([^\"]*)\" with name \"([^\"]*)\" is created$")
+    @Given("^subscription object of type \"([^\"]*)\" with name \"([^\"]*)\" is created$")
     public void subscription_object_for_with_name_is_created(String subscriptionType,
             String subscriptionName) throws Throwable {
         if (subscriptionType.equalsIgnoreCase("Mail")) {
@@ -88,11 +88,6 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
         } else {
             subscriptionObject = new RestPostSubscriptionObject(subscriptionName);
         }
-    }
-
-    @Given("^all previous steps passed$")
-    public void all_previous_steps_passed() throws Throwable {
-        // Write code here that turns the phrase above into concrete actions
     }
 
     @When("^notification meta \"([^\"]*)\" is set in subscription$")
@@ -143,7 +138,7 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
         assertEquals(200, statusCode);
     }
 
-    @Then("^failed notification for \"([^\"]*)\" should exist for subscription \"([^\"]*)\"$")
+    @Then("^failed notification of type \"([^\"]*)\" should exist for subscription \"([^\"]*)\"$")
     public void failed_notification_exists(String searchValue, String subscriptionName) throws Throwable {
         HttpRequest request = new HttpRequest(HttpMethod.GET);
         request.setBaseUrl("http://" + eiHost + ":" + port)

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -13,7 +13,6 @@ import org.apache.http.client.ClientProtocolException;
 import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -146,9 +146,6 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
                .addParam("subscriptionName", subscriptionName);
         
         ResponseEntity response = request.performRequest();
-        System.out.println("#######################################################################################");
-        System.out.println(response.getBody());
-        System.out.println("#######################################################################################");
         String message = objectMapper.readTree(response.getBody()).get("queryResponseEntity").get("message").toString();
         assertEquals(true, message.contains(searchValue));
     }

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -118,6 +118,12 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
         super.sendEventsAndConfirm();
     }
 
+    @When("^rest post body media type is set to \"([^\"]*)\" is set in subscription$")
+    public void rest_post_body_media_type_is_set_to_is_set_in_subscription(
+            String restPostBodyMediaType) throws Throwable {
+        subscriptionObject.setRestPostBodyMediaType(restPostBodyMediaType);
+    }
+
     @Then("^subscription is uploaded$")
     public void subscription_is_uploaded()
             throws URISyntaxException, ClientProtocolException, IOException {

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -48,22 +48,20 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
     private ObjectMapper objectMapper = new ObjectMapper();
     private int extraEventsCount = 0;
 
-    private long startTime;
-
     private SubscriptionObject subscriptionObject;
 
     @Given("^the rules \"([^\"]*)\"$")
-    public void the_rules(String rulesFilePath) throws Throwable {
+    public void rules(String rulesFilePath) throws Throwable {
         this.rulesFilePath = rulesFilePath;
     }
 
     @Given("^the events \"([^\"]*)\"$")
-    public void the_events(String eventsFilePath) throws Throwable {
+    public void events(String eventsFilePath) throws Throwable {
         this.eventsFilePath = eventsFilePath;
     }
 
     @Given("^subscription object of type \"([^\"]*)\" with name \"([^\"]*)\" is created$")
-    public void subscription_object_for_with_name_is_created(String subscriptionType,
+    public void subscriptionObjectOfTypeIsCreated(String subscriptionType,
             String subscriptionName) throws Throwable {
         if (subscriptionType.equalsIgnoreCase("Mail")) {
             subscriptionObject = new MailSubscriptionObject(subscriptionName);
@@ -73,40 +71,38 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
     }
 
     @When("^notification meta \"([^\"]*)\" is set in subscription$")
-    public void notification_meta_is_set_in_subscription(String notificationMeta) throws Throwable {
+    public void notificationMetaIsSetInSubscription(String notificationMeta) throws Throwable {
         subscriptionObject.setNotificationMeta(notificationMeta);
     }
 
     @When("^parameter form key \"([^\"]*)\" and form value \"([^\"]*)\" is added in subscription$")
-    public void parameter_key_and_value_is_added_in_subscription(String formKey, String formValue) {
+    public void parameterKeyAndValueIsAddedInSubscription(String formKey, String formValue) {
         subscriptionObject.addNotificationMessageKeyValue(formKey, formValue);
     }
 
     @When("^condition \"([^\"]*)\" at requirement index '(\\d+)' is added in subscription$")
-    public void requirement_for_condition_is_added_in_subscription(String condition,
+    public void conditionOrRequirementIsAddedInSubscription(String condition,
             int requirementIndex) throws Throwable {
         subscriptionObject.addConditionToRequirement(requirementIndex, new JSONObject().put(
                 "jmespath", condition));
     }
 
     @When("^the eiffel events are sent$")
-    public void eiffel_events_are_sent() throws Throwable {
+    public void eiffelEventsAreSent() throws Throwable {
         super.sendEventsAndConfirm();
     }
 
     @When("^rest post body media type is set to \"([^\"]*)\" is set in subscription$")
-    public void rest_post_body_media_type_is_set_in_subscription(
+    public void restPostBodyMediaTypeIsSetInSubscription(
             String restPostBodyMediaType) throws Throwable {
         subscriptionObject.setRestPostBodyMediaType(restPostBodyMediaType);
     }
 
     @Then("^subscription is uploaded$")
-    public void subscription_is_uploaded()
+    public void subscriptionIsUploaded()
             throws URISyntaxException, ClientProtocolException, IOException {
         assert (subscriptionObject instanceof RestPostSubscriptionObject
                 || subscriptionObject instanceof MailSubscriptionObject) : "SubscriptionObject must have been initiated.";
-
-        startTime = System.currentTimeMillis();
 
         HttpRequest postRequest = new HttpRequest(HttpMethod.POST);
         postRequest.setBaseUrl("http://" + eiHost + ":" + port)
@@ -120,7 +116,7 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
     }
 
     @Then("^failed notification of type \"([^\"]*)\" should exist for subscription \"([^\"]*)\"$")
-    public void failed_notification_exists(String searchValue, String subscriptionName) throws Throwable {
+    public void failedNotificationShouldExist(String searchValue, String subscriptionName) throws Throwable {
         HttpRequest request = new HttpRequest(HttpMethod.GET);
         request.setBaseUrl("http://" + eiHost + ":" + port)
                .setEndpoint("/queryMissedNotifications")

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -127,6 +127,9 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
                .addParam("subscriptionName", subscriptionName);
         
         ResponseEntity response = request.performRequest();
+        System.out.println("###############################################");
+        System.out.println(response.getBody());
+        System.out.println("###############################################");
         String message = objectMapper.readTree(response.getBody()).get("queryResponseEntity").get("message").toString();
         assertEquals(true, message.contains(searchValue));
     }

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -1,0 +1,210 @@
+package com.ericsson.ei.integrationtests.notification;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.client.ClientProtocolException;
+import org.json.JSONObject;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootContextLoader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+import com.ericsson.ei.App;
+import com.ericsson.eiffelcommons.subscriptionobject.MailSubscriptionObject;
+import com.ericsson.eiffelcommons.subscriptionobject.RestPostSubscriptionObject;
+import com.ericsson.eiffelcommons.subscriptionobject.SubscriptionObject;
+import com.ericsson.eiffelcommons.utils.HttpRequest;
+import com.ericsson.eiffelcommons.utils.HttpRequest.HttpMethod;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import util.IntegrationTestBase;
+
+@Ignore
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = App.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(classes = App.class, loader = SpringBootContextLoader.class)
+@TestExecutionListeners(listeners = { DependencyInjectionTestExecutionListener.class })
+@TestPropertySource(properties = { "spring.mail.port: 9999" })
+public class FailedNotificationStepsIT extends IntegrationTestBase {
+    private String jenkinsJobName;
+    private String jenkinsJobToken;
+    private String rulesFilePath;
+    private String eventsFilePath;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private int extraEventsCount = 0;
+
+    private long startTime;
+
+    @Value("${jenkins.host:http}")
+    private String jenkinsProtocol;
+
+    @Value("${jenkins.host:localhost}")
+    private String jenkinsHost;
+
+    @Value("${jenkins.port:8082}")
+    private int jenkinsPort;
+
+    @Value("${jenkins.username:admin}")
+    private String jenkinsUsername;
+
+    @Value("${jenkins.password:admin}")
+    private String jenkinsPassword;
+
+    private SubscriptionObject subscriptionObject;
+
+    @Given("^the rules \"([^\"]*)\"$")
+    public void the_rules(String rulesFilePath) throws Throwable {
+        this.rulesFilePath = rulesFilePath;
+    }
+
+    @Given("^the events \"([^\"]*)\"$")
+    public void the_events(String eventsFilePath) throws Throwable {
+        this.eventsFilePath = eventsFilePath;
+    }
+
+    @Given("^subscription object for \"([^\"]*)\" with name \"([^\"]*)\" is created$")
+    public void subscription_object_for_with_name_is_created(String subscriptionType,
+            String subscriptionName) throws Throwable {
+        if (subscriptionType.equalsIgnoreCase("Mail")) {
+            subscriptionObject = new MailSubscriptionObject(subscriptionName);
+        } else {
+            subscriptionObject = new RestPostSubscriptionObject(subscriptionName);
+        }
+    }
+
+    @Given("^all previous steps passed$")
+    public void all_previous_steps_passed() throws Throwable {
+        // Write code here that turns the phrase above into concrete actions
+    }
+
+    @When("^notification meta \"([^\"]*)\" is set in subscription$")
+    public void notification_meta_is_set_in_subscription(String notificationMeta) throws Throwable {
+        notificationMeta = replaceVariablesInNotificationMeta(notificationMeta);
+        subscriptionObject.setNotificationMeta(notificationMeta);
+    }
+
+    @When("^parameter form key \"([^\"]*)\" and form value \"([^\"]*)\" is added in subscription$")
+    public void parameter_key_and_value_is_added_in_subscription(String formKey, String formValue) {
+        subscriptionObject.addNotificationMessageKeyValue(formKey, formValue);
+    }
+
+    @When("^condition \"([^\"]*)\" at requirement index '(\\d+)' is added in subscription$")
+    public void requirement_for_condition_is_added_in_subscription(String condition,
+            int requirementIndex) throws Throwable {
+        subscriptionObject.addConditionToRequirement(requirementIndex, new JSONObject().put(
+                "jmespath", condition));
+    }
+
+    @When("^the eiffel events are sent$")
+    public void eiffel_events_are_sent() throws Throwable {
+        super.sendEventsAndConfirm();
+    }
+
+    @Then("^subscription is uploaded$")
+    public void subscription_is_uploaded()
+            throws URISyntaxException, ClientProtocolException, IOException {
+        assert (subscriptionObject instanceof RestPostSubscriptionObject
+                || subscriptionObject instanceof MailSubscriptionObject) : "SubscriptionObject must have been initiated.";
+
+        startTime = System.currentTimeMillis();
+
+        HttpRequest postRequest = new HttpRequest(HttpMethod.POST);
+        postRequest.setBaseUrl("http://" + eiHost + ":" + port)
+                   .setEndpoint("/subscriptions")
+                   .addHeader("Content-type", "application/json")
+                   .setBody(subscriptionObject.getAsSubscriptions().toString());
+
+        ResponseEntity response = postRequest.performRequest();
+        int statusCode = Integer.valueOf(response.getStatusCodeValue());
+        assertEquals(200, statusCode);
+    }
+
+    @Then("^failed notification for \"([^\"]*)\" should exist for subscription \"([^\"]*)\"$")
+    public void failed_notification_exists(String searchValue, String subscriptionName) throws Throwable {
+        HttpRequest request = new HttpRequest(HttpMethod.GET);
+        request.setBaseUrl("http://" + eiHost + ":" + port)
+               .setEndpoint("/queryMissedNotifications")
+               .addParam("subscriptionName", subscriptionName);
+        
+        ResponseEntity response = request.performRequest();
+        System.out.println("#######################################################################################");
+        System.out.println(response.getBody());
+        System.out.println("#######################################################################################");
+        String message = objectMapper.readTree(response.getBody()).get("queryResponseEntity").get("message").toString();
+        assertEquals(true, message.contains(searchValue));
+    }
+
+    @Override
+    protected String getRulesFilePath() {
+        return rulesFilePath;
+    }
+
+    @Override
+    protected String getEventsFilePath() {
+        return eventsFilePath;
+    }
+
+    @Override
+    protected Map<String, JsonNode> getCheckData() throws IOException {
+        Map<String, JsonNode> checkData = new HashMap<>();
+        return checkData;
+    }
+
+    @Override
+    protected int extraEventsCount() {
+        return extraEventsCount;
+    }
+
+    @Override
+    protected List<String> getEventNamesToSend() throws IOException {
+        ArrayList<String> eventNames = new ArrayList<>();
+        eventNames.add("event_EiffelArtifactCreatedEvent_3");
+        eventNames.add("event_EiffelTestCaseTriggeredEvent_3");
+        return eventNames;
+    }
+
+    /**
+     * Replaces given input parameters if user wishes with test defined parameters. If user want the
+     * user may specify the host, port job name and token directly in the feauture file and they
+     * will not be replaced.
+     * <p>
+     * ${jenkinsHost} is replaced with jenkins host.
+     * <p>
+     * ${jenkinsPort} is replaced with jenkins port.
+     * <p>
+     * ${jenkinsJobName} is replaced with lastcreated jenkins job name if any.
+     * <p>
+     * ${jenkinsJobToken} is replaced with last created jenkins job token if any.
+     *
+     * @param notificationMeta
+     * @return
+     */
+    private String replaceVariablesInNotificationMeta(String notificationMeta) {
+        notificationMeta = notificationMeta.replaceAll("\\$\\{jenkinsHost\\}", jenkinsHost);
+        notificationMeta = notificationMeta.replaceAll("\\$\\{jenkinsPort\\}", String.valueOf(
+                jenkinsPort));
+        notificationMeta = notificationMeta.replaceAll("\\$\\{jenkinsJobName\\}",
+                this.jenkinsJobName);
+        notificationMeta = notificationMeta.replaceAll("\\$\\{jenkinsJobToken\\}",
+                this.jenkinsJobToken);
+        return notificationMeta;
+    }
+}

--- a/src/integrationtests/java/util/IntegrationTestBase.java
+++ b/src/integrationtests/java/util/IntegrationTestBase.java
@@ -180,19 +180,7 @@ public abstract class IntegrationTestBase extends AbstractTestExecutionListener 
      * @return list of event names, that will be used in flow test
      * @throws IOException
      */
-    protected List<String> getEventNamesToSend() throws IOException {
-        ArrayList<String> eventNames = new ArrayList<>();
-
-        URL eventsInput = new File(getEventsFilePath()).toURI().toURL();
-        Iterator eventsIterator = objectMapper.readTree(eventsInput).fields();
-
-        while (eventsIterator.hasNext()) {
-            Map.Entry pair = (Map.Entry) eventsIterator.next();
-            eventNames.add(pair.getKey().toString());
-        }
-
-        return eventNames;
-    }
+    protected abstract List<String> getEventNamesToSend() throws IOException;
 
     /**
      * @return map, where key - _id of expected aggregated object value - expected
@@ -254,8 +242,8 @@ public abstract class IntegrationTestBase extends AbstractTestExecutionListener 
             throws IOException, URISyntaxException, InterruptedException {
         Iterator iterator = expectedData.entrySet().iterator();
 
-        JsonNode expectedJSON = null;
-        JsonNode actualJSON = null;
+        JsonNode expectedJSON = objectMapper.createObjectNode();
+        JsonNode actualJSON = objectMapper.createObjectNode();
 
         boolean foundMatch = false;
         while (!foundMatch && iterator.hasNext()) {

--- a/src/integrationtests/java/util/IntegrationTestBase.java
+++ b/src/integrationtests/java/util/IntegrationTestBase.java
@@ -16,8 +16,6 @@ package util;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/src/integrationtests/resources/features/ArtifactFlowIT.feature
+++ b/src/integrationtests/resources/features/ArtifactFlowIT.feature
@@ -14,14 +14,13 @@ Feature: Artifact flow Integrationtest
     Then the expected aggregated object ID is "aacc3c87-75e0-4b6d-88f5-b1a5d4e62b43"
 
     # Setup subscription
-    Given subscription object for "MAIL" with name "MailTestSubscription" is created
+    Given subscription object of type "MAIL" with name "MailTestSubscription" is created
     When notification meta "some.cool.email@ericsson.com,some.other.cool.email@ericsson.com" is set in subscription
     And parameter form key "" and form value "to_string(@)" is added in subscription
     And condition "id=='aacc3c87-75e0-4b6d-88f5-b1a5d4e62b43'" at requirement index '0' is added in subscription
     Then subscription is uploaded
 
     # Send Events and Check job triggered
-    Given all previous steps passed
     When the upstream input events are sent
     And the eiffel events are sent
     Then mongodb should contain "2" mails.

--- a/src/integrationtests/resources/features/ArtifactFlowIT.feature
+++ b/src/integrationtests/resources/features/ArtifactFlowIT.feature
@@ -2,9 +2,8 @@
 
 Feature: Artifact flow Integrationtest
 
-  Scenario:
-    Send eiffel events for artifact flow and make sure EI is triggering
-    on mail subscriptions
+  Scenario: Send eiffel events for artifact flow and make sure EI is triggering
+  on mail subscriptions
 
     # Setup Eiffel Intelligence
     Given the rules "src/main/resources/rules/ArtifactRules-Eiffel-Agen-Version.json"

--- a/src/integrationtests/resources/features/FailedNotificationIT.feature
+++ b/src/integrationtests/resources/features/FailedNotificationIT.feature
@@ -2,10 +2,9 @@
 
 Feature: Failed Notification Integrationtest
 
-  Scenario:
-    Start an artifact flow aggregation and make sure the email notification fails
-    due to incorrect SMTP server port. The port is set with @TestPropertySource
-    in the steps file.
+  Scenario: Start an artifact flow aggregation and make sure the email notification fails
+  due to incorrect SMTP server port. The port is set with @TestPropertySource
+  in the steps file.
 
     # Setup Eiffel Intelligence
     Given the rules "src/main/resources/rules/ArtifactRules-Eiffel-Agen-Version.json"
@@ -22,9 +21,8 @@ Feature: Failed Notification Integrationtest
     When the eiffel events are sent
     Then failed notification of type "MAIL" should exist for subscription "MailFailureTestSubscription"
 
-  Scenario:
-    Start an artifact flow aggregation and make sure the REST notification fails
-    due to incorrect URL.
+  Scenario: Start an artifact flow aggregation and make sure the REST notification fails
+  due to incorrect URL.
 
     # Setup Eiffel Intelligence
     Given the rules "src/main/resources/rules/ArtifactRules-Eiffel-Agen-Version.json"

--- a/src/integrationtests/resources/features/FailedNotificationIT.feature
+++ b/src/integrationtests/resources/features/FailedNotificationIT.feature
@@ -1,0 +1,23 @@
+#Author: christoffer.cortes.sjowall@ericsson.com
+
+Feature: Failed Notification Integrationtest
+
+  Scenario:
+    Send eiffel events for artifact flow and make sure email notification fails
+    due to incorrect SMTP server port
+
+    # Setup Eiffel Intelligence
+    Given the rules "src/main/resources/rules/ArtifactRules-Eiffel-Agen-Version.json"
+    And the events "src/test/resources/ArtifactFlowTestEvents.json"
+
+    # Setup subscription
+    Given subscription object for "MAIL" with name "MailFailureTestSubscription" is created
+    When notification meta "some.cool.email@ericsson.com,some.other.cool.email@ericsson.com" is set in subscription
+    And parameter form key "" and form value "to_string(@)" is added in subscription
+    And condition "testCaseExecutions[?testCaseTriggeredEventId =='ad3df0e0-404d-46ee-ab4f-3118457148f4']" at requirement index '0' is added in subscription
+    Then subscription is uploaded
+
+    # Send Events and Check job triggered
+    Given all previous steps passed
+    And the eiffel events are sent
+    Then failed notification for "email" should exist for subscription "MailFailureTestSubscription"

--- a/src/integrationtests/resources/features/FailedNotificationIT.feature
+++ b/src/integrationtests/resources/features/FailedNotificationIT.feature
@@ -12,7 +12,7 @@ Feature: Failed Notification Integrationtest
     And the events "src/test/resources/ArtifactFlowTestEvents.json"
 
     # Setup subscription
-    Given subscription object for "MAIL" with name "MailFailureTestSubscription" is created
+    Given subscription object of type "MAIL" with name "MailFailureTestSubscription" is created
     When notification meta "some.cool.email@ericsson.com,some.other.cool.email@ericsson.com" is set in subscription
     And parameter form key "" and form value "to_string(@)" is added in subscription
     And condition "testCaseExecutions[?testCaseTriggeredEventId =='ad3df0e0-404d-46ee-ab4f-3118457148f4']" at requirement index '0' is added in subscription
@@ -21,7 +21,7 @@ Feature: Failed Notification Integrationtest
     # Send Events and Check job triggered
     Given all previous steps passed
     And the eiffel events are sent
-    Then failed notification for "MAIL" should exist for subscription "MailFailureTestSubscription"
+    Then failed notification of type "MAIL" should exist for subscription "MailFailureTestSubscription"
 
   Scenario:
     Start an artifact flow aggregation and make sure the REST notification fails
@@ -32,13 +32,12 @@ Feature: Failed Notification Integrationtest
     And the events "src/test/resources/ArtifactFlowTestEvents.json"
 
     # Setup subscription
-    Given subscription object for "REST/POST" with name "RestFailureTestSubscription" is created
+    Given subscription object of type "REST/POST" with name "RestFailureTestSubscription" is created
     When notification meta "http://localhost:9999/some-endpoint" is set in subscription
     And rest post body media type is set to "application/x-www-form-urlencoded" is set in subscription
     And condition "testCaseExecutions[?testCaseTriggeredEventId =='ad3df0e0-404d-46ee-ab4f-3118457148f4']" at requirement index '0' is added in subscription
     Then subscription is uploaded
 
     # Send Events and Check job triggered
-    Given all previous steps passed
-    And the eiffel events are sent
-    Then failed notification for "REST/POST" should exist for subscription "RestFailureTestSubscription"
+    When the eiffel events are sent
+    Then failed notification of type "REST/POST" should exist for subscription "RestFailureTestSubscription"

--- a/src/integrationtests/resources/features/FailedNotificationIT.feature
+++ b/src/integrationtests/resources/features/FailedNotificationIT.feature
@@ -19,8 +19,7 @@ Feature: Failed Notification Integrationtest
     Then subscription is uploaded
 
     # Send Events and Check job triggered
-    Given all previous steps passed
-    And the eiffel events are sent
+    When the eiffel events are sent
     Then failed notification of type "MAIL" should exist for subscription "MailFailureTestSubscription"
 
   Scenario:

--- a/src/integrationtests/resources/features/FailedNotificationIT.feature
+++ b/src/integrationtests/resources/features/FailedNotificationIT.feature
@@ -3,8 +3,9 @@
 Feature: Failed Notification Integrationtest
 
   Scenario:
-    Send eiffel events for artifact flow and make sure email notification fails
-    due to incorrect SMTP server port
+    Start an artifact flow aggregation and make sure the email notification fails
+    due to incorrect SMTP server port. The port is set with @TestPropertySource
+    in the steps file.
 
     # Setup Eiffel Intelligence
     Given the rules "src/main/resources/rules/ArtifactRules-Eiffel-Agen-Version.json"
@@ -20,4 +21,24 @@ Feature: Failed Notification Integrationtest
     # Send Events and Check job triggered
     Given all previous steps passed
     And the eiffel events are sent
-    Then failed notification for "email" should exist for subscription "MailFailureTestSubscription"
+    Then failed notification for "MAIL" should exist for subscription "MailFailureTestSubscription"
+
+  Scenario:
+    Start an artifact flow aggregation and make sure the REST notification fails
+    due to incorrect URL.
+
+    # Setup Eiffel Intelligence
+    Given the rules "src/main/resources/rules/ArtifactRules-Eiffel-Agen-Version.json"
+    And the events "src/test/resources/ArtifactFlowTestEvents.json"
+
+    # Setup subscription
+    Given subscription object for "REST/POST" with name "RestFailureTestSubscription" is created
+    When notification meta "http://localhost:9999/some-endpoint" is set in subscription
+    And rest post body media type is set to "application/x-www-form-urlencoded" is set in subscription
+    And condition "testCaseExecutions[?testCaseTriggeredEventId =='ad3df0e0-404d-46ee-ab4f-3118457148f4']" at requirement index '0' is added in subscription
+    Then subscription is uploaded
+
+    # Send Events and Check job triggered
+    Given all previous steps passed
+    And the eiffel events are sent
+    Then failed notification for "REST/POST" should exist for subscription "RestFailureTestSubscription"

--- a/src/integrationtests/resources/features/SourceChangeFlowIT.feature
+++ b/src/integrationtests/resources/features/SourceChangeFlowIT.feature
@@ -21,7 +21,7 @@ Feature: Source change flow integrationtest
     Then jenkins is set up with job name "sourceChangeTestJobParam"
 
     # Setup subscription
-    Given subscription object for "REST/POST" with name "ParameterizedTriggerSubscription" is created
+    Given subscription object of type "REST/POST" with name "ParameterizedTriggerSubscription" is created
     When notification meta "http://${jenkinsHost}:${jenkinsPort}/job/${jenkinsJobName}/buildWithParameters?token='test-token-123'&test_key=id" is set in subscription
     And "BASIC_AUTH_JENKINS_CSRF" authentication with username "admin" and password "admin" is set in subscription
     And rest post body media type is set to "application/x-www-form-urlencoded" is set in subscription
@@ -58,7 +58,7 @@ Feature: Source change flow integrationtest
     Then jenkins is set up with job name "sourceChangeTestJobBodyJson"
 
     # Setup subscription
-    Given subscription object for "REST/POST" with name "ParameterInBodyTriggerSubscription" is created
+    Given subscription object of type "REST/POST" with name "ParameterInBodyTriggerSubscription" is created
     When notification meta "http://${jenkinsHost}:${jenkinsPort}/job/${jenkinsJobName}/build?token='test-token-123'" is set in subscription
     And "BASIC_AUTH_JENKINS_CSRF" authentication with username "admin" and password "admin" is set in subscription
     And rest post body media type is set to "application/x-www-form-urlencoded" is set in subscription
@@ -67,9 +67,8 @@ Feature: Source change flow integrationtest
     Then subscription is uploaded
 
     # Send Events and Check job triggered
-    Given all previous steps passed
     When the upstream input events are sent
-    When the eiffel events are sent
+    And the eiffel events are sent
     And jenkins job status data fetched
     Then verify jenkins job data timestamp is after test subscription was created
     And jenkins job status data has key "test_param_1" with value "Test Input Value"

--- a/src/integrationtests/resources/features/SourceChangeFlowIT.feature
+++ b/src/integrationtests/resources/features/SourceChangeFlowIT.feature
@@ -2,10 +2,9 @@
 
 Feature: Source change flow integrationtest
 
-  Scenario:
-    Send eiffel events for source change flow and make sure EI is triggering on
-    REST-POST subscriptions using buildWithParameters and JMESPATH extracted correct
-    data to add to parameter
+  Scenario: Send eiffel events for source change flow and make sure EI is triggering on
+  REST-POST subscriptions using buildWithParameters and JMESPATH extracted correct
+  data to add to parameter
 
     Given the rules "src/main/resources/rules/SourceChangeObjectRules-Eiffel-Agen-Version.json"
     And the events "src/test/resources/TestSourceChangeObjectEvents.json"
@@ -36,10 +35,9 @@ Feature: Source change flow integrationtest
     And jenkins job status data has key "test_key" with value "sb6efi4n-25fb-4d77-b9fd-5f2xrrefe66de47"
     And the jenkins job should be deleted
 
-  Scenario:
-    Send eiffel events for source change flow and make sure EI is triggering on
-    REST-POST subscriptions using buildWithParameters and JMESPATH extracted correct
-    data to add to parameter
+  Scenario: Send eiffel events for source change flow and make sure EI is triggering on
+  REST-POST subscriptions using buildWithParameters and JMESPATH extracted correct
+  data to add to parameter
 
     Given the rules "src/main/resources/rules/SourceChangeObjectRules-Eiffel-Agen-Version.json"
     And the events "src/test/resources/TestSourceChangeObjectEvents.json"

--- a/src/integrationtests/resources/features/SourceChangeFlowIT.feature
+++ b/src/integrationtests/resources/features/SourceChangeFlowIT.feature
@@ -29,9 +29,8 @@ Feature: Source change flow integrationtest
     Then subscription is uploaded
 
     # Send Events and Check job triggered
-    Given all previous steps passed
     When the upstream input events are sent
-    When the eiffel events are sent
+    And the eiffel events are sent
     And jenkins job status data fetched
     Then verify jenkins job data timestamp is after test subscription was created
     And jenkins job status data has key "test_key" with value "sb6efi4n-25fb-4d77-b9fd-5f2xrrefe66de47"

--- a/src/integrationtests/resources/features/TestExecutionFlowIT.feature
+++ b/src/integrationtests/resources/features/TestExecutionFlowIT.feature
@@ -29,7 +29,6 @@ Feature: Test execution flow integrationtest
     Then subscription is uploaded
 
     # Send Events and Check job triggered
-    Given all previous steps passed
     When the eiffel events are sent
     And jenkins job status data fetched
     Then verify jenkins job data timestamp is after test subscription was created

--- a/src/integrationtests/resources/features/TestExecutionFlowIT.feature
+++ b/src/integrationtests/resources/features/TestExecutionFlowIT.feature
@@ -21,7 +21,7 @@ Feature: Test execution flow integrationtest
     Then jenkins is set up with job name "testExecutionTestJobParam"
 
     # Setup subscription
-    Given subscription object for "REST/POST" with name "ParameterizedTriggerSubscription" is created
+    Given subscription object of type "REST/POST" with name "ParameterizedTriggerSubscription" is created
     When notification meta "http://${jenkinsHost}:${jenkinsPort}/job/${jenkinsJobName}/buildWithParameters?token='test-token-123'&test_key=activity_triggered_event_id" is set in subscription
     And "BASIC_AUTH_JENKINS_CSRF" authentication with username "admin" and password "admin" is set in subscription
     And rest post body media type is set to "application/x-www-form-urlencoded" is set in subscription
@@ -56,7 +56,7 @@ Feature: Test execution flow integrationtest
     Then jenkins is set up with job name "testExecutionTestJobBodyJson"
 
     # Setup subscription
-    Given subscription object for "REST/POST" with name "ParameterInBodyTriggerSubscription" is created
+    Given subscription object of type "REST/POST" with name "ParameterInBodyTriggerSubscription" is created
     When notification meta "http://${jenkinsHost}:${jenkinsPort}/job/${jenkinsJobName}/build?token='test-token-123'" is set in subscription
     And "BASIC_AUTH_JENKINS_CSRF" authentication with username "admin" and password "admin" is set in subscription
     And rest post body media type is set to "application/x-www-form-urlencoded" is set in subscription
@@ -65,9 +65,8 @@ Feature: Test execution flow integrationtest
     Then subscription is uploaded
 
     # Send Events and Check job triggered
-    Given all previous steps passed
     When the eiffel events are sent
-    When jenkins job status data fetched
+    And jenkins job status data fetched
     Then verify jenkins job data timestamp is after test subscription was created
     And jenkins job status data has key "test_param_1" with value "test_value"
     And jenkins job status data has key "test_param_2" with value "e46ef12d-25gb-4d7y-b9fd-8763re66de47"

--- a/src/integrationtests/resources/features/TestExecutionFlowIT.feature
+++ b/src/integrationtests/resources/features/TestExecutionFlowIT.feature
@@ -2,10 +2,9 @@
 
 Feature: Test execution flow integrationtest
 
-  Scenario:
-    Send eiffel events for test execution flow and make sure EI is triggering on
-    REST-POST subscriptions using buildWithParameters and JMESPATH extracted correct
-    data to add to parameter
+  Scenario: Send eiffel events for test execution flow and make sure EI is triggering on
+  REST-POST subscriptions using buildWithParameters and JMESPATH extracted correct
+  data to add to parameter
 
     # Setup Eiffel Intelligence
     Given the rules "src/main/resources/rules/TestExecutionObjectRules-Eiffel-Agen-Version.json"
@@ -35,10 +34,9 @@ Feature: Test execution flow integrationtest
     And jenkins job status data has key "test_key" with value "e46ef12d-25gb-4d7y-b9fd-8763re66de47"
     And the jenkins job should be deleted
 
-  Scenario:
-    Send eiffel events for test execution flow and make sure EI is triggering on
-    REST-POST subscriptions using build and JMESPATH extracted correct
-    data to add as a json parameter in the body. This with multiple parameters.
+  Scenario: Send eiffel events for test execution flow and make sure EI is triggering on
+  REST-POST subscriptions using build and JMESPATH extracted correct
+  data to add as a json parameter in the body. This with multiple parameters.
 
     # Setup Eiffel Intelligence
     Given the rules "src/main/resources/rules/TestExecutionObjectRules-Eiffel-Agen-Version.json"

--- a/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
@@ -71,9 +71,6 @@ public class QueryMissedNotificationControllerImpl implements QueryMissedNotific
             }
             queryResponse.setQueryResponseEntity(queryResponseEntity);
             LOGGER.debug("The response is : {}", response.toString());
-            if (processMissedNotification.deleteMissedNotification(subscriptionName)) {
-                LOGGER.debug("Missed notification with subscription name {} was successfully removed from database", subscriptionName);
-            }
             return new ResponseEntity<>(queryResponse, HttpStatus.OK);
         } catch (Exception e) {
             String errorMessage = "Internal Server Error: Failed to extract the data from the Missed Notification Object based on subscription name "

--- a/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/QueryMissedNotificationControllerImpl.java
@@ -59,7 +59,7 @@ public class QueryMissedNotificationControllerImpl implements QueryMissedNotific
      */
     @Override
     @ApiOperation(value = "Retrieve missed notifications", response = QueryResponse.class)
-    public ResponseEntity<?> getQueryMissedNotifications(@RequestParam("SubscriptionName") final String subscriptionName,
+    public ResponseEntity<?> getQueryMissedNotifications(@RequestParam(required = true) final String subscriptionName,
             final HttpServletRequest httpRequest) {
         ObjectMapper mapper = new ObjectMapper();
         QueryResponse queryResponse = new QueryResponse();

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -68,8 +68,8 @@ public class EmailSender {
         try {
             emailSender.send(message);
         } catch (MailException e) {
-            LOGGER.error("Sedning email(s) failed.\n", e);
-            throw new NotificationFailureException("Failed to send notification email!");
+            LOGGER.error("Sending email(s) to SMTP server failed.\n", e);
+            throw new NotificationFailureException("Failed to send notification email to SMTP server!\nMessage: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -68,8 +68,9 @@ public class EmailSender {
         try {
             emailSender.send(message);
         } catch (MailException e) {
-            LOGGER.error("Sending email(s) to SMTP server failed.\n", e);
-            throw new NotificationFailureException("Failed to send notification email to SMTP server!\nMessage: " + e.getMessage());
+            String errorMessage = "Failed to send MAIL notification to SMTP server!";
+            LOGGER.error(errorMessage + "\n", e);
+            throw new NotificationFailureException(errorMessage + "\nMessage: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequest.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequest.java
@@ -86,15 +86,13 @@ public class HttpRequest {
     /**
      * Perform a HTTP request to a specific url. Returns the response.
      *
-     * @return response A boolean value of the request response
      * @throws AuthenticationException, HttpClientErrorException, HttpServerErrorException,
      *                                  Exception
      */
-    public boolean perform()
+    public void perform()
             throws AuthenticationException, HttpClientErrorException, HttpServerErrorException,
             Exception {
-        boolean response = httpRequestSender.postDataMultiValue(this.url, this.request);
-        return response;
+        httpRequestSender.postDataMultiValue(this.url, this.request);
     }
 
     /**

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequest.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequest.java
@@ -87,7 +87,7 @@ public class HttpRequest {
      * @return response     A boolean value of the request response
      * @throws AuthenticationException
      */
-    public boolean perform() throws AuthenticationException {
+    public boolean perform() throws Exception {
         boolean response = httpRequestSender.postDataMultiValue(this.url, this.request);
         return response;
     }

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequest.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequest.java
@@ -87,7 +87,8 @@ public class HttpRequest {
      * Perform a HTTP request to a specific url. Returns the response.
      *
      * @return response A boolean value of the request response
-     * @throws AuthenticationException
+     * @throws AuthenticationException, HttpClientErrorException, HttpServerErrorException,
+     *                                  Exception
      */
     public boolean perform()
             throws AuthenticationException, HttpClientErrorException, HttpServerErrorException,

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequest.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequest.java
@@ -25,6 +25,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 
 import com.ericsson.ei.exception.AuthenticationException;
 import com.ericsson.ei.utils.SpringContext;
@@ -84,17 +86,19 @@ public class HttpRequest {
     /**
      * Perform a HTTP request to a specific url. Returns the response.
      *
-     * @return response     A boolean value of the request response
+     * @return response A boolean value of the request response
      * @throws AuthenticationException
      */
-    public boolean perform() throws Exception {
+    public boolean perform()
+            throws AuthenticationException, HttpClientErrorException, HttpServerErrorException,
+            Exception {
         boolean response = httpRequestSender.postDataMultiValue(this.url, this.request);
         return response;
     }
 
     /**
      * Builds a HTTP request with headers.
-     * */
+     */
     public HttpRequest build() throws AuthenticationException {
         this.subscriptionField = new SubscriptionField(this.subscriptionJson);
         prepareHeaders();
@@ -105,8 +109,7 @@ public class HttpRequest {
     }
 
     /**
-     * Prepares headers to be used in a POST request.
-     * POST.
+     * Prepares headers to be used in a POST request. POST.
      *
      * @throws AuthenticationException
      */
@@ -119,17 +122,17 @@ public class HttpRequest {
     /**
      * Creates a HTTP request based on the content type.
      *
-     * */
+     */
     private void createRequest() {
         boolean isApplicationXWwwFormUrlEncoded = MediaType.valueOf(contentType)
                                                            .equals(MediaType.APPLICATION_FORM_URLENCODED);
         if (isApplicationXWwwFormUrlEncoded) {
             request = new HttpEntity<MultiValueMap<String, String>>(
-                this.mapNotificationMessage, this.headers);
+                    this.mapNotificationMessage, this.headers);
         } else {
             request = new HttpEntity<String>(
-                String.valueOf((mapNotificationMessage.get("")).get(0)),
-                this.headers);
+                    String.valueOf((mapNotificationMessage.get("")).get(0)),
+                    this.headers);
         }
     }
 
@@ -173,8 +176,7 @@ public class HttpRequest {
     }
 
     /**
-     * Returns a boolean indicating that authentication details was provided in
-     * the subscription.
+     * Returns a boolean indicating that authentication details was provided in the subscription.
      *
      * @param authType
      * @param username

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
@@ -50,8 +50,7 @@ public class HttpRequestSender {
      * @return boolean success of the request
      * @throws AuthenticationException
      */
-    public boolean postDataMultiValue(String url, HttpEntity<?> request)
-            throws AuthenticationException {
+    public boolean postDataMultiValue(String url, HttpEntity<?> request) throws Exception {
         ResponseEntity<JsonNode> response;
 
         try {
@@ -62,13 +61,13 @@ public class HttpRequestSender {
             checkIfAuthenticationException(e);
             LOGGER.error("HTTP request failed, bad request! When trying to connect to URL: {}\n{}",
                     url, e);
-            return false;
+            throw e;
         } catch (HttpServerErrorException e) {
             LOGGER.error("HttpServerErrorException, HTTP request to url {} failed\n", url, e);
-            return false;
+            throw e;
         } catch (Exception e) {
             LOGGER.error("HTTP request to url {} failed\n", url, e);
-            return false;
+            throw e;
         }
 
         HttpStatus status = response.getStatusCode();

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
@@ -48,7 +48,8 @@ public class HttpRequestSender {
      * @param url     A String containing the URL to send request to
      * @param request A HTTP POST request
      * @return boolean success of the request
-     * @throws AuthenticationException
+     * @throws AuthenticationException, HttpClientErrorException, HttpServerErrorException,
+     *                                  Exception
      */
     public boolean postDataMultiValue(String url, HttpEntity<?> request)
             throws AuthenticationException, HttpClientErrorException, HttpServerErrorException,

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
@@ -50,7 +50,9 @@ public class HttpRequestSender {
      * @return boolean success of the request
      * @throws AuthenticationException
      */
-    public boolean postDataMultiValue(String url, HttpEntity<?> request) throws Exception {
+    public boolean postDataMultiValue(String url, HttpEntity<?> request)
+            throws AuthenticationException, HttpClientErrorException, HttpServerErrorException,
+            Exception {
         ResponseEntity<JsonNode> response;
 
         try {
@@ -76,7 +78,8 @@ public class HttpRequestSender {
 
         JsonNode body = response.getBody();
 
-        LOGGER.debug("The HTTP post request response status code is [{}] and body: {}", status, body);
+        LOGGER.debug("The HTTP post request response status code is [{}] and body: {}", status,
+                body);
 
         return httpStatusSuccess;
     }

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -131,7 +131,7 @@ public class InformSubscriber {
                     "Failed to inform subscriber '{}'\nPrepared 'missed notification' document : {}",
                     e.getMessage(), missedNotification);
             mongoDBHandler.createTTLIndex(missedNotificationDataBaseName,
-                    missedNotificationCollectionName, "Time", ttlValue);
+                    missedNotificationCollectionName, "time", ttlValue);
             saveMissedNotificationToDB(missedNotification);
         }
     }

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -148,17 +148,26 @@ public class InformSubscriber {
         boolean success = false;
         int requestTries = 0;
 
+        Exception exception = null;
         do {
             requestTries++;
             try {
                 success = request.perform();
+            } catch (AuthenticationException e) {
+                exception = e;
+                break;
             } catch (Exception e) {
-                String errorMessage = "Failed to send REST/POST notification!";
-                LOGGER.error(errorMessage + "\n", e);
-                throw new NotificationFailureException(errorMessage + "\nMessage: " + e.getMessage());
+                exception = e;
             }
             LOGGER.debug("After trying for {} time(s), the result is : {}", requestTries, success);
         } while (!success && requestTries <= failAttempt);
+
+        if (!success && exception != null) {
+            String errorMessage = "Failed to send REST/POST notification!";
+            LOGGER.error(errorMessage + "\n", exception);
+            throw new NotificationFailureException(
+                    errorMessage + "\nMessage: " + exception.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -145,26 +145,25 @@ public class InformSubscriber {
      */
     private void makeHTTPRequests(HttpRequest request)
             throws AuthenticationException, NotificationFailureException {
-        boolean success = false;
         int requestTries = 0;
-
         Exception exception = null;
         do {
             requestTries++;
             try {
-                success = request.perform();
+                request.perform();
+                exception = null;
             } catch (AuthenticationException e) {
                 exception = e;
                 break;
             } catch (Exception e) {
                 exception = e;
             }
-            LOGGER.debug("After trying for {} time(s), the result is : {}", requestTries, success);
-        } while (!success && requestTries <= failAttempt);
+            LOGGER.debug("After trying for {} time(s), the result is : {}", requestTries,
+                    exception != null);
+        } while (exception != null && requestTries <= failAttempt);
 
-        if (!success && exception != null) {
+        if (exception != null) {
             String errorMessage = "Failed to send REST/POST notification!";
-            LOGGER.error(errorMessage + "\n", exception);
             throw new NotificationFailureException(
                     errorMessage + "\nMessage: " + exception.getMessage());
         }

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -153,7 +153,9 @@ public class InformSubscriber {
             try {
                 success = request.perform();
             } catch (Exception e) {
-                throw new NotificationFailureException("Failed to send HTTP notification!\nMessage: " + e.getMessage());
+                String errorMessage = "Failed to send REST/POST notification!";
+                LOGGER.error(errorMessage + "\n", e);
+                throw new NotificationFailureException(errorMessage + "\nMessage: " + e.getMessage());
             }
             LOGGER.debug("After trying for {} time(s), the result is : {}", requestTries, success);
         } while (!success && requestTries <= failAttempt);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,7 +83,7 @@ subscription.collection.repeatFlagHandlerName: subscription_repeat_handler
 # Need to be set to True to use Test Rules page in EI-Frontend.
 # This is when you want to define new aggregation rules and test it
 # on an existing or artificially created set of events.
-testaggregated.enabled: false
+testaggregated.enabled: true
 
 # threading settings
 threads.corePoolSize: 100
@@ -125,9 +125,16 @@ er.url:
 # password should be encoded in base64. It will be decoded in EndpointSecurity.java.
 ldap.enabled: false
 ldap.server.list: [{\
-        "url": "",\
+        "url": "ldap://localhost:3891/dc=example,dc=org",\
         "base.dn": "",\
-        "username": "",\
-        "password": "",\
-        "user.filter": ""\
-    }]
+        "username": "cn=admin,dc=example,dc=org",\
+        "password": "YWRtaW4=",\
+        "user.filter": "uid={0}"\
+    },\
+    {\
+        "url": "ldap://localhost:3892/dc=example,dc=org",\
+        "base.dn": "",\
+        "username": "cn=admin,dc=example,dc=org",\
+        "password": "YWRtaW4=",\
+        "user.filter": "uid={0}"\
+    }]\

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,7 +83,7 @@ subscription.collection.repeatFlagHandlerName: subscription_repeat_handler
 # Need to be set to True to use Test Rules page in EI-Frontend.
 # This is when you want to define new aggregation rules and test it
 # on an existing or artificially created set of events.
-testaggregated.enabled: true
+testaggregated.enabled: false
 
 # threading settings
 threads.corePoolSize: 100
@@ -125,16 +125,9 @@ er.url:
 # password should be encoded in base64. It will be decoded in EndpointSecurity.java.
 ldap.enabled: false
 ldap.server.list: [{\
-        "url": "ldap://localhost:3891/dc=example,dc=org",\
+        "url": "",\
         "base.dn": "",\
-        "username": "cn=admin,dc=example,dc=org",\
-        "password": "YWRtaW4=",\
-        "user.filter": "uid={0}"\
-    },\
-    {\
-        "url": "ldap://localhost:3892/dc=example,dc=org",\
-        "base.dn": "",\
-        "username": "cn=admin,dc=example,dc=org",\
-        "password": "YWRtaW4=",\
-        "user.filter": "uid={0}"\
-    }]\
+        "username": "",\
+        "password": "",\
+        "user.filter": ""\
+    }]

--- a/src/test/java/com/ericsson/ei/notifications/InformSubscriberTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/InformSubscriberTest.java
@@ -97,7 +97,6 @@ public class InformSubscriberTest {
     @Test
     public void testRestPostTrigger() throws Exception {
         beforeRestPostTests();
-        when(httpRequest.perform()).thenReturn(true);
         informSubscriber.informSubscriber(aggregatedObject, restPostSubscriptionNode);
         verify(httpRequest, times(1)).perform();
     }
@@ -111,7 +110,7 @@ public class InformSubscriberTest {
     @Test
     public void testRestPostTriggerFailure() throws Exception {
         beforeRestPostTests();
-        when(httpRequest.perform()).thenReturn(false);
+        doThrow(new Exception("")).when(httpRequest).perform();
 
         informSubscriber.informSubscriber(aggregatedObject, restPostSubscriptionNode);
         // Should expect 4 tries to perform a HTTP request
@@ -129,7 +128,7 @@ public class InformSubscriberTest {
     @Test
     public void testRestPostTriggerThrowsAuthenticationException() throws Exception {
         beforeRestPostTests();
-        when(httpRequest.perform()).thenThrow(new AuthenticationException(""));
+        doThrow(new AuthenticationException("")).when(httpRequest).perform();
 
         informSubscriber.informSubscriber(aggregatedObject, restPostSubscriptionNode);
         // Should expect 1 tries to perform a HTTP request since AuthenticationException should

--- a/src/test/java/com/ericsson/ei/queryservice/test/QueryServiceRESTAPITest.java
+++ b/src/test/java/com/ericsson/ei/queryservice/test/QueryServiceRESTAPITest.java
@@ -135,7 +135,7 @@ public class QueryServiceRESTAPITest {
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders.get("/queryMissedNotifications?")
                                                               .accept(MediaType.APPLICATION_JSON)
-                                                              .param("SubscriptionName",
+                                                              .param("subscriptionName",
                                                                       "Subscription_1");
         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
 

--- a/src/test/resources/MissedNotification.json
+++ b/src/test/resources/MissedNotification.json
@@ -1,10 +1,10 @@
 {
     "subscriptionName": "Subscription_1",
     "notificationMeta": "some_url",
-    "Time": {
+    "time": {
         "$date": "2019-08-29T06:29:00.000Z"
     },
-    "AggregatedObject": {
+    "aggregatedObject": {
         "fileInformation": [
             {
                 "extension": "jar",

--- a/src/test/resources/MissedNotificationOutput.json
+++ b/src/test/resources/MissedNotificationOutput.json
@@ -2,10 +2,10 @@
     {
         "subscriptionName": "Subscription_1",
         "notificationMeta": "some_url",
-        "Time": {
+        "time": {
             "$date": "2019-08-29T06:29:00.000Z"
         },
-        "AggregatedObject": {
+        "aggregatedObject": {
             "fileInformation": [
                 {
                     "extension": "jar",

--- a/wiki/markdown/query.md
+++ b/wiki/markdown/query.md
@@ -192,3 +192,22 @@ Examples of this endpoint using curl
 
     curl -X GET -H "Content-type: application/json" localhost:39835/queryMissedNotifications?SubscriptionName=Subscription_1
 
+The content of a failed notification json object may look something like the following
+
+    {
+        "subscriptionName": "RestFailureTestSubscription",
+        "aggregatedObject": {
+            ...
+        },
+        "notificationMeta": "http://localhost:9999/some-endpoint",
+        "_id": {
+            "$oid": "5d807a1d821b960af311fab3"
+        },
+        "time": {
+            "$date": "2019-09-17T06:15:57.000Z"
+        },
+        "message": "Failed to send REST/POST notification!\nMessage: I/O error on POST request for \"http://localhost:9999/some-endpoint\": Connect to localhost:9999 [localhost/127.0.0.1] failed: Connection refused (Connection refused); nested exception is org.apache.http.conn.HttpHostConnectException: Connect to localhost:9999 [localhost/127.0.0.1] failed: Connection refused (Connection refused)"
+    }
+
+It contains the name of the subscription that failed, a snapshot of the aggregated object that triggered the subscription, the notification meta which is the mail or endpoint to contact, the time of occurence and the message that contains the exception that was thrown.
+This information is meant to help you figure out why the notification failed. In the example above the reason is that the notification meta URL is invalid and because of this could not establish a connection.

--- a/wiki/markdown/query.md
+++ b/wiki/markdown/query.md
@@ -209,5 +209,5 @@ The content of a failed notification json object may look something like the fol
         "message": "Failed to send REST/POST notification!\nMessage: I/O error on POST request for \"http://localhost:9999/some-endpoint\": Connect to localhost:9999 [localhost/127.0.0.1] failed: Connection refused (Connection refused); nested exception is org.apache.http.conn.HttpHostConnectException: Connect to localhost:9999 [localhost/127.0.0.1] failed: Connection refused (Connection refused)"
     }
 
-It contains the name of the subscription that failed, a snapshot of the aggregated object that triggered the subscription, the notification meta which is the mail or endpoint to contact, the time of occurence and the message that contains the exception that was thrown.
+It contains the name of the subscription that failed, a snapshot of the aggregated object that triggered the subscription, the notification meta which is the mail or service endpoint to contact, the time of occurence and the message that contains the exception that was thrown.
 This information is meant to help you figure out why the notification failed. In the example above the reason is that the notification meta URL is invalid and because of this could not establish a connection.

--- a/wiki/markdown/subscription-with-REST-POST-notification.md
+++ b/wiki/markdown/subscription-with-REST-POST-notification.md
@@ -39,6 +39,7 @@ _**Subscription templates can be found [here](https://github.com/eiffel-communit
         "notificationType" : "REST_POST",
 
         // Which url to use for the HTTP POST request.
+        // This field requires a schema to work. That means the 'http://' part needs to be included.
         "notificationMeta" : "http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
 
         // Headers for the HTTP request, can be 'application/x-www-form-urlencoded' or 'application/json'.


### PR DESCRIPTION
### Applicable Issues
https://github.com/eiffel-community/eiffel-intelligence/issues/254

### Description of the Change
Error message is now part of the failed notification object.

### Alternate Designs

### Benefits
Useful for the failed notifications feature in the front-end. The idea is the be able to see what notification failed and the reason.

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
