### PR TITLE
Remove REST API listing from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,6 @@ Visit [Eiffel Community](https://eiffel-community.github.io) to get started and 
     - [**ArtifactPublishedEvent Aggregation**](wiki/markdown/artifact-published-event-aggregation.md)
     - [**ConfidenceLevelModifiedEvent Aggregation**](wiki/markdown/confidence-level-modified-event-aggregation.md)
 5. [**REST API**](wiki/markdown/REST-API.md)
-    - [**Query aggregated objects**](wiki/markdown/query.md)
-    - [**Running rules on objects**](wiki/markdown/running-rules-on-objects.md)
-    - [**Authentication**](wiki/markdown/authentication.md)
-    - [**Subscriptions**](wiki/markdown/subscription-API.md)
-    - [**Status**](wiki/markdown/status.md)
-    - [**Download files**](wiki/markdown/download-files.md)
 6. [**Compatibility**](wiki/markdown/compatibility.md)
 7. [**Known limitations**](wiki/markdown/known-limitations.md)
 


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
Removed the REST API listing from the README since it kept being out of sync with the REST-API.md page.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @Christoffer-Cortes 
