### PR TITLE
Fix bug where LDAP password was displayed when fetching EI information

### DIFF
--- a/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
+++ b/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
@@ -16,28 +16,32 @@
 */
 package com.ericsson.ei.controller.model;
 
-import com.ericsson.ei.erqueryservice.ERQueryService;
-import com.ericsson.ei.handlers.ObjectHandler;
-import com.ericsson.ei.handlers.RmqHandler;
-import com.ericsson.ei.notifications.EmailSender;
-import com.ericsson.ei.notifications.InformSubscriber;
-import com.ericsson.ei.subscription.SubscriptionHandler;
-import com.ericsson.ei.waitlist.WaitListStorageHandler;
-import lombok.Getter;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
 import javax.annotation.PostConstruct;
 
+import org.json.JSONArray;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import com.ericsson.ei.erqueryservice.ERQueryService;
+import com.ericsson.ei.handlers.ObjectHandler;
+import com.ericsson.ei.handlers.RmqHandler;
+import com.ericsson.ei.notifications.EmailSender;
+import com.ericsson.ei.notifications.InformSubscriber;
+import com.ericsson.ei.subscription.SubscriptionHandler;
+import com.ericsson.ei.utils.SafeLdapServer;
+import com.ericsson.ei.waitlist.WaitListStorageHandler;
+
+import lombok.Getter;
+
 /**
- * Parsing all classes which contains value annotation in eiffel-intelligence plugin.
- * Needed for generate Json file with information about backend instance.
+ * Parsing all classes which contains value annotation in eiffel-intelligence plugin. Needed for
+ * generate Json file with information about backend instance.
  */
 @Component
 public class ParseInstanceInfoEI {
@@ -106,7 +110,8 @@ public class ParseInstanceInfoEI {
     @PostConstruct
     public void init() throws IOException {
         Properties properties = new Properties();
-        properties.load(ParseInstanceInfoEI.class.getResourceAsStream("/default-application.properties"));
+        properties.load(
+                ParseInstanceInfoEI.class.getResourceAsStream("/default-application.properties"));
         version = properties.getProperty("version");
         applicationName = properties.getProperty("artifactId");
     }
@@ -156,8 +161,23 @@ public class ParseInstanceInfoEI {
         private String enabled;
 
         @Getter
-        @Value("${ldap.server.list}")
-        private String servers;
+        private String ldapServerList;
+
+        @Autowired
+        private Environment env;
+
+        /**
+         * Extracts ldap.server.list content and creates a new safe to display ldap server list.
+         *
+         * @throws IOException
+         */
+        @PostConstruct
+        public void init() throws IOException {
+            final String ldapServers = env.getProperty("ldap.server.list");
+            final JSONArray serverList = SafeLdapServer.createLdapSettingsArray(ldapServers);
+            ldapServerList = serverList.toString(2);
+        }
+
     }
 
     @Component

--- a/src/main/java/com/ericsson/ei/utils/SafeLdapServer.java
+++ b/src/main/java/com/ericsson/ei/utils/SafeLdapServer.java
@@ -1,15 +1,36 @@
+/*
+   Copyright 2019 Ericsson AB.
+   For a full list of individual contributors, please see the commit history.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package com.ericsson.ei.utils;
 
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+/**
+ * This class should ensure the safety of an LDAP server list by creating a new JSONArray where the
+ * objects inside does not have the key and value for password.
+ *
+ */
 public class SafeLdapServer {
 
     /**
-     * By creating our own LDAP setting object to display we have control of what values are
-     * shown to the user. This also makes it impossible to slip unwanted values by mistake if
-     * the user configure the property with misspelled keys.
+     * By creating our own LDAP setting object to display we have control of what values are shown
+     * to the user. This also makes it impossible to slip unwanted values by mistake if the user
+     * configure the property with misspelled keys.
      *
      * @param String :
      * @return JSONArray

--- a/src/main/java/com/ericsson/ei/utils/SafeLdapServer.java
+++ b/src/main/java/com/ericsson/ei/utils/SafeLdapServer.java
@@ -1,0 +1,46 @@
+package com.ericsson.ei.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class SafeLdapServer {
+
+    /**
+     * By creating our own LDAP setting object to display we have control of what values are
+     * shown to the user. This also makes it impossible to slip unwanted values by mistake if
+     * the user configure the property with misspelled keys.
+     *
+     * @param String :
+     * @return JSONArray
+     */
+    public static JSONArray createLdapSettingsArray(String inputServerList) {
+        if (StringUtils.isBlank(inputServerList)) {
+            return new JSONArray();
+        }
+        JSONArray modifiedServerList = new JSONArray();
+
+        final JSONArray serverList = new JSONArray(inputServerList);
+        serverList.forEach(item -> {
+            JSONObject ldapServer = (JSONObject) item;
+            JSONObject modifiedLdapServer = extractLdapValues(ldapServer);
+            modifiedServerList.put(modifiedLdapServer);
+        });
+        return modifiedServerList;
+    }
+
+    /**
+     * Extracts the specified values from the input JSONObject to the returned JSONObject.
+     *
+     * @param JSONObject
+     * @return JSONObject
+     */
+    private static JSONObject extractLdapValues(JSONObject ldapServer) {
+        JSONObject modifiedLdapServer = new JSONObject();
+        modifiedLdapServer.put("user.filter", ldapServer.get("user.filter"));
+        modifiedLdapServer.put("base.dn", ldapServer.get("base.dn"));
+        modifiedLdapServer.put("username", ldapServer.get("username"));
+        modifiedLdapServer.put("url", ldapServer.get("url"));
+        return modifiedLdapServer;
+    }
+}

--- a/src/test/java/com/ericsson/ei/utils/SafeLdapServerTest.java
+++ b/src/test/java/com/ericsson/ei/utils/SafeLdapServerTest.java
@@ -1,10 +1,13 @@
 /*
    Copyright 2019 Ericsson AB.
    For a full list of individual contributors, please see the commit history.
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
+
        http://www.apache.org/licenses/LICENSE-2.0
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,17 +66,6 @@ public class SafeLdapServerTest {
         assertSafeLdapServerList(serverList);
     }
 
-    private void assertSafeLdapServerList(JSONArray serverList) {
-        serverList.forEach(item -> {
-            JSONObject ldapServer = (JSONObject) item;
-            Set<String> keys = ldapServer.keySet();
-            assertFalse("Safe LDAP object should not contain key password",
-                    keys.contains(PASSWORD_KEY));
-            assertTrue("Safe LDAP object should contain key url", keys.contains(URL_KEY));
-            assertEquals("Safe LDAP object url value", URL_VALUE, ldapServer.get(URL_KEY));
-        });
-    }
-
     @Test
     public void testInputValueNull() throws Exception {
         final JSONArray serverList = SafeLdapServer.createLdapSettingsArray("");
@@ -86,4 +78,14 @@ public class SafeLdapServerTest {
         assertEquals("Safe LDAP server list should be empty", 0, serverList.length());
     }
 
+    private void assertSafeLdapServerList(JSONArray serverList) {
+        serverList.forEach(item -> {
+            JSONObject ldapServer = (JSONObject) item;
+            Set<String> keys = ldapServer.keySet();
+            assertFalse("Safe LDAP object should not contain key password",
+                    keys.contains(PASSWORD_KEY));
+            assertTrue("Safe LDAP object should contain key url", keys.contains(URL_KEY));
+            assertEquals("Safe LDAP object url value", URL_VALUE, ldapServer.get(URL_KEY));
+        });
+    }
 }

--- a/src/test/java/com/ericsson/ei/utils/SafeLdapServerTest.java
+++ b/src/test/java/com/ericsson/ei/utils/SafeLdapServerTest.java
@@ -1,0 +1,89 @@
+/*
+   Copyright 2019 Ericsson AB.
+   For a full list of individual contributors, please see the commit history.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.ericsson.ei.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class SafeLdapServerTest {
+
+    private static final String PASSWORD_KEY = "password";
+    private static final String URL_KEY = "url";
+    private static final String URL_VALUE = "my-url";
+
+    private static final String SINGLE_LDAP_SERVER = "[{"
+            + " \"url\": \"" + URL_VALUE + "\","
+            + " \"base.dn\": \"\","
+            + " \"username\": \"\","
+            + " \"password\": \"\","
+            + " \"user.filter\": \"\""
+            + " }]";
+    private static final String MULTIPLE_LDAP_SERVER =  "[{"
+            + " \"url\": \"" + URL_VALUE + "\","
+            + " \"base.dn\": \"\","
+            + " \"username\": \"\","
+            + " \"password\": \"\","
+            + " \"user.filter\": \"\""
+            + " },"
+            + "{"
+            + " \"url\": \"" + URL_VALUE + "\","
+            + " \"base.dn\": \"\","
+            + " \"username\": \"\","
+            + " \"password\": \"\","
+            + " \"user.filter\": \"\""
+            + " }]";
+
+    @Test
+    public void testSingleLdapServer() throws Exception {
+        final JSONArray serverList = SafeLdapServer.createLdapSettingsArray(SINGLE_LDAP_SERVER);
+        assertSafeLdapServerList(serverList);
+    }
+
+    @Test
+    public void testMultipleLdapServer() throws Exception {
+        final JSONArray serverList = SafeLdapServer.createLdapSettingsArray(MULTIPLE_LDAP_SERVER);
+        assertSafeLdapServerList(serverList);
+    }
+
+    private void assertSafeLdapServerList(JSONArray serverList) {
+        serverList.forEach(item -> {
+            JSONObject ldapServer = (JSONObject) item;
+            Set<String> keys = ldapServer.keySet();
+            assertFalse("Safe LDAP object should not contain key password",
+                    keys.contains(PASSWORD_KEY));
+            assertTrue("Safe LDAP object should contain key url", keys.contains(URL_KEY));
+            assertEquals("Safe LDAP object url value", URL_VALUE, ldapServer.get(URL_KEY));
+        });
+    }
+
+    @Test
+    public void testInputValueNull() throws Exception {
+        final JSONArray serverList = SafeLdapServer.createLdapSettingsArray("");
+        assertEquals("Safe LDAP server list should be empty", 0, serverList.length());
+    }
+
+    @Test
+    public void testInputValueEmpty() throws Exception {
+        final JSONArray serverList = SafeLdapServer.createLdapSettingsArray("");
+        assertEquals("Safe LDAP server list should be empty", 0, serverList.length());
+    }
+
+}


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
LDAP password was displayed when accessing /information endpoint in EI
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
/information will now display a safe version of the LDAP settings.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
