### PR TITLE
Replacement marker mismatch handled better

### DIFF
--- a/src/main/java/com/ericsson/ei/exception/ReplacementMarkerException.java
+++ b/src/main/java/com/ericsson/ei/exception/ReplacementMarkerException.java
@@ -1,0 +1,10 @@
+package com.ericsson.ei.exception;
+
+public class ReplacementMarkerException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ReplacementMarkerException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ericsson/ei/exception/ReplacementMarkerException.java
+++ b/src/main/java/com/ericsson/ei/exception/ReplacementMarkerException.java
@@ -1,6 +1,6 @@
 package com.ericsson.ei.exception;
 
-public class ReplacementMarkerException extends RuntimeException {
+public class ReplacementMarkerException extends Exception {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
@@ -52,11 +52,10 @@ public class MatchIdRulesHandler {
         List<String> objects = new ArrayList<>();
         try {
             objects = doFetchObjectsById(matchIdString, id);
-            return objects;
         } catch (ReplacementMarkerException e) {
             LOGGER.warn("", e);
-            return  objects;
         }
+        return  objects;
     }
 
     /**
@@ -75,7 +74,7 @@ public class MatchIdRulesHandler {
      * @return an updated matchIdString
      * @throws ReplacementMarkerException
      */
-    public String replaceIdInRules(String matchIdString, String id) throws ReplacementMarkerException {
+    protected String replaceIdInRules(String matchIdString, String id) throws ReplacementMarkerException {
         if (matchIdString.contains(replacementMarker)) {
             return matchIdString.replace(replacementMarker, id);
         } else {

--- a/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
@@ -53,6 +53,7 @@ public class MatchIdRulesHandler {
         try {
             objects = doFetchObjectsById(matchIdString, id);
         } catch (ReplacementMarkerException e) {
+            // The outer for loop must not stop because of this exception but logging is still wanted.
             LOGGER.warn("", e);
         }
         return  objects;

--- a/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
@@ -18,7 +18,11 @@ package com.ericsson.ei.rules;
 
 import java.util.List;
 
+import com.ericsson.ei.exception.ReplacementMarkerException;
 import com.ericsson.ei.handlers.ObjectHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -29,6 +33,8 @@ import com.ericsson.ei.rules.RulesObject;
 
 @Component
 public class MatchIdRulesHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MatchIdRulesHandler.class);
 
     @Value("${rules.replacement.marker:%IdentifyRulesEventId%}")
     private String replacementMarker;
@@ -67,7 +73,10 @@ public class MatchIdRulesHandler {
         if (matchIdString.contains(replacementMarker)) {
             return matchIdString.replace(replacementMarker, id);
         } else {
-            return null;
+            String errorMessage = String.format("Failed to find rules.replacement.marker:%s in MatchIdRules: %s", replacementMarker, matchIdString);
+            ReplacementMarkerException exception = new ReplacementMarkerException(errorMessage);
+            LOGGER.warn("", exception);
+            throw exception;
         }
     }
 

--- a/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
@@ -53,8 +53,7 @@ public class MatchIdRulesHandler {
         try {
             objects = doFetchObjectsById(matchIdString, id);
         } catch (ReplacementMarkerException e) {
-            // The outer for loop must not stop because of this exception but logging is still wanted.
-            LOGGER.warn("", e);
+            LOGGER.error("Replacement marker mismatch.", e);
         }
         return  objects;
     }

--- a/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/rules/MatchIdRulesHandler.java
@@ -73,7 +73,7 @@ public class MatchIdRulesHandler {
         if (matchIdString.contains(replacementMarker)) {
             return matchIdString.replace(replacementMarker, id);
         } else {
-            String errorMessage = String.format("Failed to find rules.replacement.marker:%s in MatchIdRules: %s", replacementMarker, matchIdString);
+            String errorMessage = String.format("MatchIdRules: %s does not contain the rules.replacement.marker: %s", matchIdString, replacementMarker);
             ReplacementMarkerException exception = new ReplacementMarkerException(errorMessage);
             LOGGER.warn("", exception);
             throw exception;

--- a/src/test/java/com/ericsson/ei/extraction/test/TestExtractionHandler.java
+++ b/src/test/java/com/ericsson/ei/extraction/test/TestExtractionHandler.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import com.ericsson.ei.handlers.ExtractionHandler;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
-import com.ericsson.ei.rules.test.TestRulesHandler;
+import com.ericsson.ei.rules.TestRulesHandler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/com/ericsson/ei/rules/MatchIdRulesHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/rules/MatchIdRulesHandlerTest.java
@@ -14,7 +14,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-package com.ericsson.ei.rules.test;
+package com.ericsson.ei.rules;
 
 import static org.junit.Assert.assertEquals;
 
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.ericsson.ei.exception.ReplacementMarkerException;
-import com.ericsson.ei.rules.MatchIdRulesHandler;
 import com.ericsson.ei.rules.RulesObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/com/ericsson/ei/rules/TestIdRulesHandler.java
+++ b/src/test/java/com/ericsson/ei/rules/TestIdRulesHandler.java
@@ -14,55 +14,52 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-package com.ericsson.ei.rules.test;
+package com.ericsson.ei.rules;
 
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.ericsson.ei.rules.RulesHandler;
+import com.ericsson.ei.rules.IdRulesHandler;
+import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-public class TestRulesHandler {
+public class TestIdRulesHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestRulesHandler.class);
-    private static final String INPUT_FILE_PATH = "src/test/resources/EiffelSourceChangeCreatedEvent.json";
-    private static final String OUTPUT_FILE_PATH = "src/test/resources/RulesHandlerOutput.json";
     private static final String RULES_PATH = "src/test/resources/ArtifactRules.json";
-
-    private RulesHandler unitUnderTest;
-
-    @Before
-    public void setUp() throws Exception {
-        System.setProperty("rules.path", RULES_PATH);
-        unitUnderTest = new RulesHandler();
-        unitUnderTest.init();
-    }
+    private static final String EVENT_PATH = "src/test/resources/EiffelArtifactCreatedEvent.json";
 
     @Test
-    public void testPrintJson() {
-        String jsonInput = null;
-        String jsonOutput;
-        RulesObject result;
-        RulesObject output = null;
-        try {
-            jsonInput = FileUtils.readFileToString(new File(INPUT_FILE_PATH), "UTF-8");
-            jsonOutput = FileUtils.readFileToString(new File(OUTPUT_FILE_PATH), "UTF-8");
-            ObjectMapper objectmapper = new ObjectMapper();
-            output = new RulesObject(objectmapper.readTree(jsonOutput));
+    public void testGetIds(){
+        RulesObject rulesObject = null;
+        String eventFile = "";
+        String expectedIds = "e90daae3-bf3f-4b0a-b899-67834fd5ebd0";
+
+        IdRulesHandler idRulesHandler = new IdRulesHandler();
+        JmesPathInterface jmespath = new JmesPathInterface();
+        idRulesHandler.setJmesPathInterface(jmespath);
+        try{
+            String jsonRules = FileUtils.readFileToString(new File(RULES_PATH), "UTF-8");
+            ObjectMapper rulesObjectMapper = new ObjectMapper();
+            eventFile = FileUtils.readFileToString(new File(EVENT_PATH), "UTF-8");
+            rulesObject = new RulesObject(rulesObjectMapper.readTree(jsonRules.replace("[", "").replace("]", "")));
+            LOGGER.debug("RulesObject: {}", rulesObject.getJsonRulesObject());
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
         }
-        result = unitUnderTest.getRulesForEvent(jsonInput);
-        assertEquals(result, output);
+        JsonNode ids = idRulesHandler.getIds(rulesObject, eventFile);
+        LOGGER.debug("Ids: {}", ids.textValue());
+
+        assertEquals(expectedIds, ids.textValue());
     }
 }

--- a/src/test/java/com/ericsson/ei/rules/TestRulesHandler.java
+++ b/src/test/java/com/ericsson/ei/rules/TestRulesHandler.java
@@ -14,52 +14,55 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-package com.ericsson.ei.rules.test;
+package com.ericsson.ei.rules;
 
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.ericsson.ei.rules.IdRulesHandler;
-import com.ericsson.ei.jmespath.JmesPathInterface;
+import com.ericsson.ei.rules.RulesHandler;
 import com.ericsson.ei.rules.RulesObject;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-public class TestIdRulesHandler {
+public class TestRulesHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestRulesHandler.class);
+    private static final String INPUT_FILE_PATH = "src/test/resources/EiffelSourceChangeCreatedEvent.json";
+    private static final String OUTPUT_FILE_PATH = "src/test/resources/RulesHandlerOutput.json";
     private static final String RULES_PATH = "src/test/resources/ArtifactRules.json";
-    private static final String EVENT_PATH = "src/test/resources/EiffelArtifactCreatedEvent.json";
+
+    private RulesHandler unitUnderTest;
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("rules.path", RULES_PATH);
+        unitUnderTest = new RulesHandler();
+        unitUnderTest.init();
+    }
 
     @Test
-    public void testGetIds(){
-        RulesObject rulesObject = null;
-        String eventFile = "";
-        String expectedIds = "e90daae3-bf3f-4b0a-b899-67834fd5ebd0";
-
-        IdRulesHandler idRulesHandler = new IdRulesHandler();
-        JmesPathInterface jmespath = new JmesPathInterface();
-        idRulesHandler.setJmesPathInterface(jmespath);
-        try{
-            String jsonRules = FileUtils.readFileToString(new File(RULES_PATH), "UTF-8");
-            ObjectMapper rulesObjectMapper = new ObjectMapper();
-            eventFile = FileUtils.readFileToString(new File(EVENT_PATH), "UTF-8");
-            rulesObject = new RulesObject(rulesObjectMapper.readTree(jsonRules.replace("[", "").replace("]", "")));
-            LOGGER.debug("RulesObject: {}", rulesObject.getJsonRulesObject());
+    public void testPrintJson() {
+        String jsonInput = null;
+        String jsonOutput;
+        RulesObject result;
+        RulesObject output = null;
+        try {
+            jsonInput = FileUtils.readFileToString(new File(INPUT_FILE_PATH), "UTF-8");
+            jsonOutput = FileUtils.readFileToString(new File(OUTPUT_FILE_PATH), "UTF-8");
+            ObjectMapper objectmapper = new ObjectMapper();
+            output = new RulesObject(objectmapper.readTree(jsonOutput));
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
         }
-        JsonNode ids = idRulesHandler.getIds(rulesObject, eventFile);
-        LOGGER.debug("Ids: {}", ids.textValue());
-
-        assertEquals(expectedIds, ids.textValue());
+        result = unitUnderTest.getRulesForEvent(jsonInput);
+        assertEquals(result, output);
     }
 }

--- a/src/test/java/com/ericsson/ei/rules/TestRulesObject.java
+++ b/src/test/java/com/ericsson/ei/rules/TestRulesObject.java
@@ -14,7 +14,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-package com.ericsson.ei.rules.test;
+package com.ericsson.ei.rules;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/com/ericsson/ei/rules/TestRulesRestAPI.java
+++ b/src/test/java/com/ericsson/ei/rules/TestRulesRestAPI.java
@@ -14,7 +14,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-package com.ericsson.ei.rules.test;
+package com.ericsson.ei.rules;
 
 import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;

--- a/src/test/java/com/ericsson/ei/rules/TestRulesService.java
+++ b/src/test/java/com/ericsson/ei/rules/TestRulesService.java
@@ -1,4 +1,4 @@
-package com.ericsson.ei.rules.test;
+package com.ericsson.ei.rules;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
We encountered an error with replacement marker mismatch with an unclear error message.

### Description of the Change
When MatchIdRules does not contain the rules.replacement.marker the error will be clearly logged and an exception will be thrown at that point instead of around 10 steps further in the code.

**Error message:**
"MatchIdRules: {"_id":"%IdentifyRulesEventIds%"} does not contain the rules.replacement.marker: %IdentifyRulesEventId%"

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
