### PR TITLE
Added default sender and subject values for email notification.

### DIFF
--- a/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
@@ -195,16 +195,10 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
         eventManager.sendEiffelEvents(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend);
     }
 
-    @Then("^Then Notification email contains <our expected> values")
-    public void notification_email_contains_expected_values() {
-        sender = "noreply@ericsson.com";
-        subject = "Email Subscription Notification";
-    }
-
-    @Then("^Notification email contains default values$")
-    public void notification_email_contains_default_values() {
-        assertEquals("noreply@ericsson.com", sender);
-        assertEquals("Email Subscription Notification", subject);
+    @Then("^Then Notification email contains {String} and {String} values")
+    public void notification_email_contains_expected_values(String sender, String subject) {
+        assertEquals(sender, emailSender.getSender());
+        assertEquals(subject, emailSender.getSubject());
     }
 
     @Then("^Mail subscriptions were triggered$")

--- a/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
@@ -70,6 +70,9 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
     @Value("${email.sender}")
     private String sender;
 
+    @Value("${email.subject}")
+    private String subject;
+
     @Value("${aggregations.collection.name}")
     private String aggregatedCollectionName;
 
@@ -187,6 +190,18 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
         eventManager.sendEiffelEvents(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend);
     }
 
+    @Then("^Default values mail notification are assigned$")
+    public void default_values_mail_notification() {
+        if (sender == null && subject == null) {
+            sender = "noreply@ericsson.com";
+            subject = "Email Subscription Notification";
+        } else if (sender == null && subject != null) {
+            sender = "noreply@ericsson.com";
+        } else if (sender != null && subject == null) {
+            subject = "Email Subscription Notification";
+        }
+    }
+
     @Then("^Mail subscriptions were triggered$")
     public void mail_subscriptions_were_triggered() {
         LOGGER.debug("Verifying received emails.");
@@ -196,6 +211,8 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
         for (SmtpMessage email : emails) {
             // assert correct sender.
             assertEquals("Assert correct email sender: ", email.getHeaderValue("From"), sender);
+            // assert correct subject.
+            assertEquals("Assert correct email subject: ", email.getHeaderValue("Subject"), subject);
             // assert given test case exist in body.
             assert (email.getBody().contains("TC5"));
         }

--- a/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.Ignore;
+import org.mockito.InjectMocks;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Format;
@@ -34,6 +35,7 @@ import com.dumbster.smtp.SimpleSmtpServer;
 import com.dumbster.smtp.SmtpMessage;
 import com.ericsson.ei.mongo.MongoCondition;
 import com.ericsson.ei.mongo.MongoDBHandler;
+import com.ericsson.ei.notifications.EmailSender;
 import com.ericsson.ei.utils.FunctionalTestBase;
 import com.ericsson.ei.utils.HttpRequest;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -90,6 +92,9 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
 
     @Autowired
     private MongoDBHandler mongoDBHandler;
+
+    @InjectMocks
+    private EmailSender emailSender;
 
     private SimpleSmtpServer smtpServer;
     private ClientAndServer restServer;
@@ -190,15 +195,11 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
         eventManager.sendEiffelEvents(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend);
     }
 
-    @Then("^Default values mail notification are assigned$")
+    @Then("^Default values mail notification are added$")
     public void default_values_mail_notification() {
-        if (sender == null && subject == null) {
-            sender = "noreply@ericsson.com";
-            subject = "Email Subscription Notification";
-        } else if (sender == null && subject != null) {
-            sender = "noreply@ericsson.com";
-        } else if (sender != null && subject == null) {
-            subject = "Email Subscription Notification";
+        if (emailSender.getSender() != null && emailSender.getSubject() != null) {
+            assertEquals("noreply@ericsson.com", emailSender.getSender());
+            assertEquals("Email Subscription Notification", emailSender.getSubject());
         }
     }
 

--- a/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
@@ -197,9 +197,15 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
 
     @Then("^Default values mail notification are added$")
     public void default_values_mail_notification() {
+        if (emailSender.getSender() != null && emailSender.getSubject() != null) {
             assertEquals("noreply@ericsson.com", emailSender.getSender());
             assertEquals("Email Subscription Notification", emailSender.getSubject());
+        } else if (emailSender.getSender() != null && emailSender.getSubject() == null) {
+            assertEquals("noreply@ericsson.com", emailSender.getSender());
+        } else if (emailSender.getSender() == null && emailSender.getSubject() != null) {
+            assertEquals("Email Subscription Notification", emailSender.getSubject());
         }
+    }
 
     @Then("^Mail subscriptions were triggered$")
     public void mail_subscriptions_were_triggered() {

--- a/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
@@ -195,7 +195,7 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
         eventManager.sendEiffelEvents(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend);
     }
 
-    @Then("^Then Notification email contains {String} and {String} values")
+    @Then("^Then Notification email contains ('(.*?)') and ('(.*?)') values")
     public void notification_email_contains_expected_values(String sender, String subject) {
         assertEquals(sender, emailSender.getSender());
         assertEquals(subject, emailSender.getSubject());

--- a/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
@@ -197,11 +197,9 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
 
     @Then("^Default values mail notification are added$")
     public void default_values_mail_notification() {
-        if (emailSender.getSender() != null && emailSender.getSubject() != null) {
             assertEquals("noreply@ericsson.com", emailSender.getSender());
             assertEquals("Email Subscription Notification", emailSender.getSubject());
         }
-    }
 
     @Then("^Mail subscriptions were triggered$")
     public void mail_subscriptions_were_triggered() {

--- a/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
@@ -195,16 +195,16 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
         eventManager.sendEiffelEvents(EIFFEL_EVENTS_JSON_PATH, eventNamesToSend);
     }
 
-    @Then("^Default values mail notification are added$")
-    public void default_values_mail_notification() {
-        if (emailSender.getSender() != null && emailSender.getSubject() != null) {
-            assertEquals("noreply@ericsson.com", emailSender.getSender());
-            assertEquals("Email Subscription Notification", emailSender.getSubject());
-        } else if (emailSender.getSender() != null && emailSender.getSubject() == null) {
-            assertEquals("noreply@ericsson.com", emailSender.getSender());
-        } else if (emailSender.getSender() == null && emailSender.getSubject() != null) {
-            assertEquals("Email Subscription Notification", emailSender.getSubject());
-        }
+    @Then("^Then Notification email contains <our expected> values")
+    public void notification_email_contains_expected_values() {
+        sender = "noreply@ericsson.com";
+        subject = "Email Subscription Notification";
+    }
+
+    @Then("^Notification email contains default values$")
+    public void notification_email_contains_default_values() {
+        assertEquals("noreply@ericsson.com", sender);
+        assertEquals("Email Subscription Notification", subject);
     }
 
     @Then("^Mail subscriptions were triggered$")

--- a/src/functionaltests/resources/features/subscriptionNotification.feature
+++ b/src/functionaltests/resources/features/subscriptionNotification.feature
@@ -31,6 +31,6 @@ Feature: Test Subscription Trigger
     And Subscriptions are created
     When I send Eiffel events
     And Wait for EI to aggregate objects
-    Then Notification email contains "noreply@ericsson.com" and "Email Subscription Notification" values
+    Then Notification email contains "noreply@domain.com" and "Email Subscription Notification" values
     Then Mail subscriptions were triggered
     And Rest subscriptions were triggered

--- a/src/functionaltests/resources/features/subscriptionNotification.feature
+++ b/src/functionaltests/resources/features/subscriptionNotification.feature
@@ -30,6 +30,6 @@ Feature: Test Subscription Trigger
     And Subscriptions are created
     When I send Eiffel events
     And Wait for EI to aggregate objects
-    Then Default values mail notification are assigned
+    Then Default values mail notification are added
     Then Mail subscriptions were triggered
     And Rest subscriptions were triggered

--- a/src/functionaltests/resources/features/subscriptionNotification.feature
+++ b/src/functionaltests/resources/features/subscriptionNotification.feature
@@ -8,6 +8,7 @@ Feature: Test Subscription Trigger
     And Subscriptions are created
     When I send Eiffel events
     And Wait for EI to aggregate objects
+    Then Notification email contains <our expected> values
     Then Mail subscriptions were triggered
     And Rest subscriptions were triggered
     When I send one previous event again
@@ -30,6 +31,6 @@ Feature: Test Subscription Trigger
     And Subscriptions are created
     When I send Eiffel events
     And Wait for EI to aggregate objects
-    Then Default values mail notification are added
+    Then Notification email contains default values
     Then Mail subscriptions were triggered
     And Rest subscriptions were triggered

--- a/src/functionaltests/resources/features/subscriptionNotification.feature
+++ b/src/functionaltests/resources/features/subscriptionNotification.feature
@@ -31,6 +31,6 @@ Feature: Test Subscription Trigger
     And Subscriptions are created
     When I send Eiffel events
     And Wait for EI to aggregate objects
-    Then Notification email contains default values
+    Then Notification email contains "noreply@ericsson.com" and "Email Subscription Notification" values
     Then Mail subscriptions were triggered
     And Rest subscriptions were triggered

--- a/src/functionaltests/resources/features/subscriptionNotification.feature
+++ b/src/functionaltests/resources/features/subscriptionNotification.feature
@@ -22,3 +22,14 @@ Feature: Test Subscription Trigger
     When I send one previous event again
     And Wait for EI to aggregate objects
     And Failed notification db should contain 2 objects
+
+  @AddedDefaultValuesSenderAndSubject
+  Scenario: Test default values mail notification
+    Given The REST API is up and running
+    And Mail server is up
+    And Subscriptions are created
+    When I send Eiffel events
+    And Wait for EI to aggregate objects
+    Then Default values mail notification are assigned
+    Then Mail subscriptions were triggered
+    And Rest subscriptions were triggered

--- a/src/functionaltests/resources/features/subscriptionNotification.feature
+++ b/src/functionaltests/resources/features/subscriptionNotification.feature
@@ -31,6 +31,6 @@ Feature: Test Subscription Trigger
     And Subscriptions are created
     When I send Eiffel events
     And Wait for EI to aggregate objects
-    Then Notification email contains "noreply@domain.com" and "Email Subscription Notification" values
+    Then Notification email contains 'noreply@domain.com' and 'Email Subscription Notification' values
     Then Mail subscriptions were triggered
     And Rest subscriptions were triggered

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -83,7 +83,6 @@ public class EmailSender {
      * */
     public MimeMessage prepareEmailMessage(String recipients, String mapNotificationMessage,
             String emailSubject) {
-        setDefaultValues();
         Set<String> emails = new HashSet<>();
         emails = extractEmails(recipients);
         String[] to = emails.toArray(new String[0]);
@@ -92,10 +91,10 @@ public class EmailSender {
     }
 
     /*
-     * This method assigns the default values of sender and subject of email notification if values
+     * This method assigns the default values for sender and subject of email notification if values
      * at application.proporties are empty.
      * */
-    private void setDefaultValues() {
+    private void setDefaultValuesEmailSenderSubject() {
        if (subject.isEmpty()) {
             subject = "Email Subscription Notification";
         }
@@ -113,6 +112,7 @@ public class EmailSender {
      */
     private MimeMessage prepareEmail(String mapNotificationMessage, String emailSubject,
             String[] recipients) {
+        setDefaultValuesEmailSenderSubject();
         MimeMessage message = emailSender.createMimeMessage();
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -48,12 +48,12 @@ public class EmailSender {
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailSender.class);
 
     @Getter
-    @Value("${email.sender}")
-    private String sender;
+    @Value("${email.sender:noreply@ericsson.com}")
+    private static final String SENDER = "noreply@ericsson.com";
 
     @Getter
-    @Value("${email.subject}")
-    private String subject;
+    @Value("${email.subject:Email Subscription Notification}")
+    private static final String SUBJECT = "Email Subscription Notification";
 
     @Autowired
     private JavaMailSender emailSender;
@@ -102,7 +102,7 @@ public class EmailSender {
         MimeMessage message = emailSender.createMimeMessage();
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
-            helper.setFrom(sender);
+            helper.setFrom(SENDER);
             helper.setSubject(getSubject(emailSubject));
             helper.setText(mapNotificationMessage);
             helper.setTo(recipients);
@@ -138,7 +138,7 @@ public class EmailSender {
      */
     private String getSubject(String emailSubject) {
         if (emailSubject.isEmpty()) {
-            return subject;
+            return SUBJECT;
         }
         return emailSubject;
     }

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -49,28 +49,14 @@ public class EmailSender {
 
     @Getter
     @Value("${email.sender:noreply@ericsson.com}")
-    private static final String SENDER = "noreply@ericsson.com";
+    private String sender;
 
     @Getter
     @Value("${email.subject:Email Subscription Notification}")
-    private static final String SUBJECT = "Email Subscription Notification";
+    private String subject;
 
     @Autowired
     private JavaMailSender emailSender;
-
-    /**
-     * @return the sender
-     */
-    public String getSender() {
-        return SENDER;
-    }
-
-    /**
-     * @return the subject
-     */
-    public String getSubject() {
-        return SUBJECT;
-    }
 
 /**
      * This method sends an email.
@@ -97,11 +83,27 @@ public class EmailSender {
      * */
     public MimeMessage prepareEmailMessage(String recipients, String mapNotificationMessage,
             String emailSubject) {
+        setDefaultValues();
         Set<String> emails = new HashSet<>();
         emails = extractEmails(recipients);
         String[] to = emails.toArray(new String[0]);
         MimeMessage message = prepareEmail(mapNotificationMessage, emailSubject, to);
         return message;
+    }
+
+    /*
+     * This method assigns the default values of sender and subject of email notification if values
+     * at application.proporties are empty.
+     * */
+    private void setDefaultValues() {
+        if (sender.isEmpty() && subject.isEmpty()) {
+            sender = "noreply@ericsson.com";
+            subject = "Email Subscription Notification";
+        } else if (!sender.isEmpty() && subject.isEmpty()) {
+            subject = "Email Subscription Notification";
+        } else if (sender.isEmpty() && !subject.isEmpty()) {
+            sender = "noreply@ericsson.com";
+        }
     }
 
     /**
@@ -113,10 +115,23 @@ public class EmailSender {
      */
     private MimeMessage prepareEmail(String mapNotificationMessage, String emailSubject,
             String[] recipients) {
+        if(sender.isEmpty() && subject.isEmpty())
+        {
+            sender = "noreply@ericsson.com";
+            subject = "Email Subscription Notification";
+        }
+        else if(!sender.isEmpty() && subject.isEmpty())
+        {
+            subject = "Email Subscription Notification";
+        }
+        else if(sender.isEmpty() && !subject.isEmpty())
+        {
+            sender = "noreply@ericsson.com";
+        }
         MimeMessage message = emailSender.createMimeMessage();
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
-            helper.setFrom(SENDER);
+            helper.setFrom(sender);
             helper.setSubject(getSubject(emailSubject));
             helper.setText(mapNotificationMessage);
             helper.setTo(recipients);
@@ -152,7 +167,7 @@ public class EmailSender {
      */
     private String getSubject(String emailSubject) {
         if (emailSubject.isEmpty()) {
-            return SUBJECT;
+            return subject;
         }
         return emailSubject;
     }

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -96,10 +96,10 @@ public class EmailSender {
      * at application.proporties are empty.
      * */
     private void setDefaultValuesEmailSenderSubject() {
-       if (StringUtils.isEmpty(subject) == true) {
+       if (StringUtils.isEmpty(subject)) {
             subject = "Email Subscription Notification";
         }
-       if (StringUtils.isEmpty(sender) == true) {
+       if (StringUtils.isEmpty(sender)) {
             sender = "noreply@domain.com";
         }
     }

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -115,19 +115,6 @@ public class EmailSender {
      */
     private MimeMessage prepareEmail(String mapNotificationMessage, String emailSubject,
             String[] recipients) {
-        if(sender.isEmpty() && subject.isEmpty())
-        {
-            sender = "noreply@ericsson.com";
-            subject = "Email Subscription Notification";
-        }
-        else if(!sender.isEmpty() && subject.isEmpty())
-        {
-            subject = "Email Subscription Notification";
-        }
-        else if(sender.isEmpty() && !subject.isEmpty())
-        {
-            sender = "noreply@ericsson.com";
-        }
         MimeMessage message = emailSender.createMimeMessage();
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,10 +96,10 @@ public class EmailSender {
      * at application.proporties are empty.
      * */
     private void setDefaultValuesEmailSenderSubject() {
-       if (subject.isEmpty()) {
+       if (StringUtils.isEmpty(subject) == true) {
             subject = "Email Subscription Notification";
         }
-       if (sender.isEmpty()) {
+       if (StringUtils.isEmpty(sender) == true) {
             sender = "noreply@domain.com";
         }
     }

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -48,7 +48,7 @@ public class EmailSender {
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailSender.class);
 
     @Getter
-    @Value("${email.sender:noreply@ericsson.com}")
+    @Value("${email.sender:noreply@domain.com}")
     private String sender;
 
     @Getter
@@ -99,7 +99,7 @@ public class EmailSender {
             subject = "Email Subscription Notification";
         }
        if (sender.isEmpty()) {
-            sender = "noreply@ericsson.com";
+            sender = "noreply@domain.com";
         }
     }
 

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -59,6 +59,20 @@ public class EmailSender {
     private JavaMailSender emailSender;
 
     /**
+     * @return the sender
+     */
+    public String getSender() {
+        return SENDER;
+    }
+
+    /**
+     * @return the subject
+     */
+    public String getSubject() {
+        return SUBJECT;
+    }
+
+/**
      * This method sends an email.
      *
      * @param message   The email message to send

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -96,12 +96,10 @@ public class EmailSender {
      * at application.proporties are empty.
      * */
     private void setDefaultValues() {
-        if (sender.isEmpty() && subject.isEmpty()) {
-            sender = "noreply@ericsson.com";
+       if (subject.isEmpty()) {
             subject = "Email Subscription Notification";
-        } else if (!sender.isEmpty() && subject.isEmpty()) {
-            subject = "Email Subscription Notification";
-        } else if (sender.isEmpty() && !subject.isEmpty()) {
+        }
+       if (sender.isEmpty()) {
             sender = "noreply@ericsson.com";
         }
     }

--- a/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.doThrow;
 import javax.mail.internet.MimeMessage;
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -44,12 +45,6 @@ public class EmailSenderTest {
     @InjectMocks
     private EmailSender emailSender;
 
-    @Value("${email.sender:noreply@ericsson.com}")
-    private String sender;
-
-    @Value("${email.subject:Email notification}")
-    private String subject;
-
     @Test(expected = NotificationFailureException.class)
     public void sendEmailThrowsException() throws Exception {
         doThrow(new MailSendException("")).when(javaMailSender).send(message);
@@ -58,13 +53,9 @@ public class EmailSenderTest {
 
     @Test
     public void testDefaultValues() {
-        if (sender == null && subject == null) {
-            sender = "noreply@ericsson.com";
-            subject = "Email Subscription Notification";
-        } else if (sender == null && subject != null) {
-            sender = "noreply@ericsson.com";
-        } else if (sender != null && subject == null) {
-            subject = "Email Subscription Notification";
+        if (emailSender.getSender() != null && emailSender.getSubject() != null) {
+            assertEquals("noreply@ericsson.com", emailSender.getSender());
+            assertEquals("Email Subscription Notification", emailSender.getSubject());
         }
     }
 

--- a/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
@@ -56,6 +56,10 @@ public class EmailSenderTest {
         if (emailSender.getSender() != null && emailSender.getSubject() != null) {
             assertEquals("noreply@ericsson.com", emailSender.getSender());
             assertEquals("Email Subscription Notification", emailSender.getSubject());
+        } else if (emailSender.getSender() != null && emailSender.getSubject() == null) {
+            assertEquals("noreply@ericsson.com", emailSender.getSender());
+        } else if (emailSender.getSender() == null && emailSender.getSubject() != null) {
+            assertEquals("Email Subscription Notification", emailSender.getSubject());
         }
     }
 

--- a/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
@@ -51,9 +51,9 @@ public class EmailSenderTest {
         emailSender.sendEmail(message);
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testDefaultValues() {
-        assertEquals("noreply@ericsson.com", emailSender.getSender());
+        assertEquals("noreply@domain.com", emailSender.getSender());
         assertEquals("Email Subscription Notification", emailSender.getSubject());
     }
 

--- a/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
@@ -51,12 +51,6 @@ public class EmailSenderTest {
         emailSender.sendEmail(message);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testDefaultValues() {
-        assertEquals("noreply@domain.com", emailSender.getSender());
-        assertEquals("Email Subscription Notification", emailSender.getSubject());
-    }
-
     /*
      * prepareEmail is not possible to test due too much hidden Spring mumbo jumbo doing things in
      * background.

--- a/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -43,14 +44,33 @@ public class EmailSenderTest {
     @InjectMocks
     private EmailSender emailSender;
 
+    @Value("${email.sender:noreply@ericsson.com}")
+    private String sender;
+
+    @Value("${email.subject:Email notification}")
+    private String subject;
+
     @Test(expected = NotificationFailureException.class)
     public void sendEmailThrowsException() throws Exception {
         doThrow(new MailSendException("")).when(javaMailSender).send(message);
         emailSender.sendEmail(message);
     }
 
+    @Test
+    public void testDefaultValues() {
+        if (sender == null && subject == null) {
+            sender = "noreply@ericsson.com";
+            subject = "Email Subscription Notification";
+        } else if (sender == null && subject != null) {
+            sender = "noreply@ericsson.com";
+        } else if (sender != null && subject == null) {
+            subject = "Email Subscription Notification";
+        }
+    }
+
     /*
      * prepareEmail is not possible to test due too much hidden Spring mumbo jumbo doing things in
      * background.
      */
+
 }

--- a/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
@@ -53,14 +53,8 @@ public class EmailSenderTest {
 
     @Test
     public void testDefaultValues() {
-        if (emailSender.getSender() != null && emailSender.getSubject() != null) {
-            assertEquals("noreply@ericsson.com", emailSender.getSender());
-            assertEquals("Email Subscription Notification", emailSender.getSubject());
-        } else if (emailSender.getSender() != null && emailSender.getSubject() == null) {
-            assertEquals("noreply@ericsson.com", emailSender.getSender());
-        } else if (emailSender.getSender() == null && emailSender.getSubject() != null) {
-            assertEquals("Email Subscription Notification", emailSender.getSubject());
-        }
+        assertEquals("noreply@ericsson.com", emailSender.getSender());
+        assertEquals("Email Subscription Notification", emailSender.getSubject());
     }
 
     /*

--- a/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
@@ -18,12 +18,10 @@ import static org.mockito.Mockito.doThrow;
 import javax.mail.internet.MimeMessage;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
https://github.com/eiffel-community/eiffel-intelligence/issues/401

### Description of the Change
Added sender and subject default values for email notification.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
We will always have email sender and subject defined, even if users do not defined them in their application.properties.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
