### PR TITLE
Fixed NullPointerException when mongoDB connection goes down

### DIFF
--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -37,6 +37,7 @@ import com.ericsson.ei.subscription.SubscriptionHandler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClientException;
 import com.mongodb.util.JSON;
 
 import lombok.Getter;
@@ -152,7 +153,7 @@ public class ObjectHandler {
      * @param query query to base search on
      * @return List of documents
      */
-    public List<String> findObjectsByCondition(MongoQuery query) {
+    public List<String> findObjectsByCondition(MongoQuery query) throws MongoClientException {
         return mongoDbHandler.find(databaseName, collectionName, query);
     }
 
@@ -162,7 +163,7 @@ public class ObjectHandler {
      * @param id An id to search for in the database
      * @return document
      */
-    public String findObjectById(String id) {
+    public String findObjectById(String id) throws MongoClientException {
         final MongoCondition condition = MongoCondition.idCondition(id);
         String document = "";
         List<String> documents = findObjectsByCondition(condition);

--- a/src/main/java/com/ericsson/ei/handlers/UpStreamEventsHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/UpStreamEventsHandler.java
@@ -83,6 +83,12 @@ public class UpStreamEventsHandler {
         }
 
         final JsonNode upstreamLinkObjects = searchResult.get("upstreamLinkObjects");
+
+        if (upstreamLinkObjects == null) {
+            LOGGER.warn("Asked for upstream from {} but got null result back!", aggregatedObjectId);
+            return;
+        }
+
         if (!upstreamLinkObjects.isArray()) {
             LOGGER.warn("Expected upstreamLinkObjects to be an array but is: {}", upstreamLinkObjects.getNodeType());
         }

--- a/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
@@ -52,7 +52,6 @@ import com.mongodb.util.JSON;
 import lombok.Getter;
 import lombok.Setter;
 
-@SuppressWarnings("deprecation")
 @Component
 public class MongoDBHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBHandler.class);

--- a/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
@@ -123,7 +123,7 @@ public class MongoDBHandler {
                 }
             }
         } catch (Exception e) {
-            LOGGER.error("Failed to retrieve documents as {}", e.getMessage());
+            LOGGER.error("Failed to retrieve documents from the collection {} as {}", collectionName, e.getMessage());
         }
         return result;
     }

--- a/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
@@ -370,14 +370,14 @@ public class MongoDBHandler {
             throw new MongoClientException("Failed to connect MongoDB");
         }
 
-        verifyExistanceOfCollection(databaseName, collectionName);
+        verifyExistenceOfCollection(databaseName, collectionName);
 
         MongoDatabase db = mongoClient.getDatabase(databaseName);
         MongoCollection<Document> collection = db.getCollection(collectionName);
         return collection;
     }
 
-    private void verifyExistanceOfCollection(String databaseName, String collectionName) throws MongoClientException {
+    private void verifyExistenceOfCollection(String databaseName, String collectionName) throws MongoClientException {
         List<String> collectionList = getCollectionList(databaseName);
         if (!collectionList.contains(collectionName)) {
             createCollection(databaseName, collectionName);

--- a/src/main/java/com/ericsson/ei/waitlist/WaitListWorker.java
+++ b/src/main/java/com/ericsson/ei/waitlist/WaitListWorker.java
@@ -61,6 +61,9 @@ public class WaitListWorker {
     private EventToObjectMapHandler eventToObjectMapHandler;
 
     private boolean shutdownInProgress = false;
+    private static final String ID = "_id";
+    private static final String EVENT = "Event";
+    private static final String TIME = "Time";
 
     @Scheduled(initialDelayString = "${waitlist.resend.initial.delay}", fixedRateString = "${waitlist.resend.fixed.rate}")
     public void run() {
@@ -88,7 +91,7 @@ public class WaitListWorker {
     private void checkAggregationsExistAndRepublishEvent(String document) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode eventJson = objectMapper.readTree(document);
-        String id = eventJson.get("_id").asText();
+        String id = eventJson.get(ID).asText();
         if (eventToObjectMapHandler.isEventInEventObjectMap(id)) {
             waitListStorageHandler.dropDocumentFromWaitList(document);
         } else {
@@ -97,7 +100,7 @@ public class WaitListWorker {
     }
 
     public void checkTargetAggregationsExistAndRepublishEvent(JsonNode eventJson) {
-        JsonNode event = eventJson.get("Event");
+        JsonNode event = eventJson.get(EVENT);
         String eventStr = event.asText();
         RulesObject rulesObject = rulesHandler.getRulesForEvent(eventStr);
         String idRule = rulesObject.getIdentifyRules();
@@ -106,8 +109,8 @@ public class WaitListWorker {
         if (idRule != null && !idRule.isEmpty()) {
             JsonNode ids = jmesPathInterface.runRuleOnEvent(idRule, eventStr);
             if (ids.isArray()) {
-                JsonNode idNode = eventJson.get("_id");
-                JsonNode timeNode = eventJson.get("Time");
+                JsonNode idNode = eventJson.get(ID);
+                JsonNode timeNode = eventJson.get(TIME);
                 LOGGER.debug("[EIFFEL EVENT RESENT FROM WAITLIST: {}] id:{} time:{}", waitlistId, idNode.textValue(),
                         timeNode);
                 for (final JsonNode idJsonObj : ids) {


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
Fix: https://github.com/eiffel-community/eiffel-intelligence/issues/387

### Description of the Change
Previously when EI looses connection with mongoDB we will get nullpointer exceptions in several places in the code.
So Handled the NullPointerException by giving proper error log messages and also in some places handled errors by throwing MongoClientException instead of returning null.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Whenever MongoDB goes down, will get error message instead of NullPointerException.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
