### PR TITLE
Improve /information endpoint response

### DIFF
--- a/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
+++ b/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
@@ -41,17 +41,13 @@ import com.ericsson.ei.waitlist.WaitListStorageHandler;
 import lombok.Getter;
 
 /**
- * Parsing all classes which contains value annotation in eiffel-intelligence plugin. Needed for
- * generate Json file with information about backend instance.
+ * Parsing all classes which contains value annotation in Eiffel Intelligence. Needed for
+ * generating JSON file with information about backend instance.
  */
 @Component
 public class ParseInstanceInfoEI {
     @Autowired
     private Environment environment;
-
-    @Getter
-    @Value("${build.version:#{null}}")
-    private String applicationPropertiesVersion;
 
     @Getter
     private String version;
@@ -65,7 +61,7 @@ public class ParseInstanceInfoEI {
 
     @Getter
     @Value("${test.aggregation.enabled:false}")
-    private String testRulesEnabled;
+    private String testAggregationEnabled;
 
     @Getter
     @Autowired
@@ -109,7 +105,7 @@ public class ParseInstanceInfoEI {
 
     @Getter
     @Autowired
-    private ERQueryService erUrl;
+    private ERQueryService eventRepository;
 
     @PostConstruct
     public void init() throws IOException {
@@ -164,7 +160,7 @@ public class ParseInstanceInfoEI {
     private class LdapValues {
         @Getter
         @Value("${ldap.enabled}")
-        private String enabled;
+        private String ldapEnabled;
 
         @Getter
         private String ldapServerList;

--- a/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
+++ b/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
@@ -51,7 +51,7 @@ public class ERQueryService {
 
     @Getter
     @Value("${event.repository.url}")
-    private String erBaseUrl;
+    private String eventRepositoryUrl;
 
     public ERQueryService() {
         this.request = new HttpRequest();
@@ -90,7 +90,7 @@ public class ERQueryService {
     private ResponseEntity sendRequestToER(String eventId, SearchOption searchOption, int limit,
             int levels, boolean tree) throws IOException, URISyntaxException,
             ClientProtocolException, PropertyNotFoundException {
-        if (StringUtils.isBlank(erBaseUrl)) {
+        if (StringUtils.isBlank(eventRepositoryUrl)) {
             throw new PropertyNotFoundException("The URL to ER is not provided");
         }
 
@@ -103,7 +103,7 @@ public class ERQueryService {
         final SearchParameters searchParameters = getSearchParameters(searchOption);
         request
                .setHttpMethod(HttpMethod.POST)
-               .setBaseUrl(erBaseUrl)
+               .setBaseUrl(eventRepositoryUrl)
                .setEndpoint(eventId)
                .addParam("limit", Integer.toString(limit))
                .addParam("levels", Integer.toString(levels))

--- a/src/main/java/com/ericsson/ei/handlers/DateUtils.java
+++ b/src/main/java/com/ericsson/ei/handlers/DateUtils.java
@@ -14,17 +14,17 @@ public class DateUtils {
 
     /**
      * This method creates the date object with the current date for appending
-     * in the document object before inserting it into mongoDB.
+     * in the document object before inserting it into Mongo DB.
      */
     public static Date getDate() throws ParseException {
-	Date date = new Date();
-	try {
-	    DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-	    String time = dateFormat.format(date);
-	    date = dateFormat.parse(time);
-	} catch (Exception e) {
-	    LOGGER.error("Failed to create date/time object.", e);
-	}
-	return date;
+        Date date = new Date();
+        try {
+            DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+            String time = dateFormat.format(date);
+            date = dateFormat.parse(time);
+        } catch (Exception e) {
+            LOGGER.error("Failed to create date/time object.", e);
+        }
+        return date;
     }
 }

--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -20,6 +20,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -281,7 +282,7 @@ public class ObjectHandler {
      */
     public int getTtl() {
         int ttl = 0;
-        if (aggregationsTtl != null && !aggregationsTtl.isEmpty()) {
+        if (!StringUtils.isEmpty(aggregationsTtl)) {
             try {
                 ttl = Integer.parseInt(aggregationsTtl);
             } catch (NumberFormatException e) {

--- a/src/main/java/com/ericsson/ei/handlers/RMQProperties.java
+++ b/src/main/java/com/ericsson/ei/handlers/RMQProperties.java
@@ -76,7 +76,7 @@ public class RMQProperties {
     @Getter
     @Setter
     @Value("${rabbitmq.waitlist.queue.suffix}")
-    private String waitlistSuffix;
+    private String waitlistQueueSuffix;
 
     @Getter
     @Setter
@@ -96,6 +96,6 @@ public class RMQProperties {
     public String getWaitlistQueueName() {
         final String durableName = this.queueDurable ? "durable" : "transient";
         return this.domainId + "." + this.componentName + "." + this.queueSuffix + "." + durableName + "."
-                + this.waitlistSuffix;
+                + this.waitlistQueueSuffix;
     }
 }

--- a/src/main/java/com/ericsson/ei/mongo/MongoCondition.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoCondition.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class MongoCondition implements MongoQuery {
 
-    private static final String ID = "_id";
     private static final String LOCK = "lock";
     private static final String SUBSCRIPTION_ID = "subscriptionId";
     private static final String SUBSCRIPTION_NAME = "subscriptionName";
@@ -37,7 +36,7 @@ public class MongoCondition implements MongoQuery {
      * @return A MongoCondition with id set
      */
     public static MongoCondition idCondition(String documentId) {
-        return condition(ID, documentId);
+        return condition(MongoConstants.ID, documentId);
     }
 
     /**
@@ -96,7 +95,7 @@ public class MongoCondition implements MongoQuery {
      * <p>
      * <code>{"lock":"0"}
      *
-     * @param lockValue
+     * @param lock
      * @return A MongoCondition with lock set
      */
     public static MongoCondition lockCondition(String lock) {

--- a/src/main/java/com/ericsson/ei/mongo/MongoConstants.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoConstants.java
@@ -1,0 +1,8 @@
+package com.ericsson.ei.mongo;
+
+public class MongoConstants {
+    public static final String ID = "_id";
+    public static final String EVENT = "Event";
+    public static final String TIME = "Time";
+    public static final String NOT_LOCKED = "0";
+}

--- a/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
@@ -241,7 +241,7 @@ public class MongoDBHandler {
     /**
      * This method is used to drop a database. For example after testing.
      *
-     * @param dataBaseName to know which database to remove
+     * @param databaseName to know which database to remove
      */
     public void dropDatabase(String databaseName) {
         MongoDatabase db = mongoClient.getDatabase(databaseName);

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -20,6 +20,7 @@ import java.text.ParseException;
 
 import javax.mail.internet.MimeMessage;
 
+import com.ericsson.ei.mongo.MongoConstants;
 import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,7 +133,7 @@ public class InformSubscriber {
                     "Failed to inform subscriber '{}'\nPrepared 'failed notification' document : {}",
                     e.getMessage(), failedNotification);
             mongoDBHandler.createTTLIndex(database,
-                    failedNotificationCollectionName, "time", failedNotificationsTtl);
+                    failedNotificationCollectionName, MongoConstants.TIME, failedNotificationsTtl);
             saveFailedNotificationToDB(failedNotification);
         }
     }
@@ -197,7 +198,7 @@ public class InformSubscriber {
         document.put("subscriptionName", subscriptionName);
         document.put("notificationMeta", notificationMeta);
         try {
-            document.put("time", DateUtils.getDate());
+            document.put(MongoConstants.TIME, DateUtils.getDate());
         } catch (ParseException e) {
             LOGGER.error("Failed to get date object.", e);
         }

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -60,7 +60,7 @@ public class InformSubscriber {
     @Setter
     @Getter
     @Value("${notification.retry:#{0}}")
-    private int failAttempt;
+    private int notificationRetry;
 
     @Getter
     @Value("${failed.notifications.collection.name}")
@@ -72,7 +72,7 @@ public class InformSubscriber {
 
     @Getter
     @Value("${failed.notifications.collection.ttl}")
-    private int ttlValue;
+    private int failedNotificationsTtl;
 
     @Autowired
     private JmesPathInterface jmespath;
@@ -132,7 +132,7 @@ public class InformSubscriber {
                     "Failed to inform subscriber '{}'\nPrepared 'failed notification' document : {}",
                     e.getMessage(), failedNotification);
             mongoDBHandler.createTTLIndex(database,
-                    failedNotificationCollectionName, "time", ttlValue);
+                    failedNotificationCollectionName, "time", failedNotificationsTtl);
             saveFailedNotificationToDB(failedNotification);
         }
     }
@@ -161,7 +161,7 @@ public class InformSubscriber {
             }
             LOGGER.debug("After trying for {} time(s), the result is : {}", requestTries,
                     exception != null);
-        } while (exception != null && requestTries <= failAttempt);
+        } while (exception != null && requestTries <= notificationRetry);
 
         if (exception != null) {
             String errorMessage = "Failed to send REST/POST notification!";

--- a/src/main/java/com/ericsson/ei/queryservice/ProcessQueryParams.java
+++ b/src/main/java/com/ericsson/ei/queryservice/ProcessQueryParams.java
@@ -13,6 +13,7 @@
 */
 package com.ericsson.ei.queryservice;
 
+import com.ericsson.ei.mongo.MongoConstants;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -102,7 +103,8 @@ public class ProcessQueryParams {
         JmesPathInterface jmesPathInterface = new JmesPathInterface();
         try {
             for (int i = 0; i < resultAggregatedObjectArray.length(); i++) {
-                String objectId = ((JSONObject) resultAggregatedObjectArray.get(i)).get("_id").toString();
+                String objectId =
+                        ((JSONObject) resultAggregatedObjectArray.get(i)).get(MongoConstants.ID).toString();
                 JsonNode filteredData = jmesPathInterface.runRuleOnEvent(filter, resultAggregatedObjectArray.get(i).toString());
                 JSONObject tempJson = new JSONObject();
                 tempJson.put(objectId, filteredData);

--- a/src/main/java/com/ericsson/ei/subscription/SubscriptionHandler.java
+++ b/src/main/java/com/ericsson/ei/subscription/SubscriptionHandler.java
@@ -52,7 +52,7 @@ public class SubscriptionHandler {
 
     @Getter
     @Value("${spring.data.mongodb.database}")
-    private String subscriptionDataBaseName;
+    private String database;
 
     @Autowired
     private InformSubscriber informSubscriber;
@@ -76,7 +76,7 @@ public class SubscriptionHandler {
                                            final String id) {
         Thread subscriptionThread = new Thread(() -> {
             List<String> subscriptions = mongoDBHandler.getAllDocuments(
-                subscriptionDataBaseName, subscriptionCollectionName);
+                    database, subscriptionCollectionName);
             subscriptions.forEach(
                 subscription -> extractConditions(aggregatedObject,
                     subscription, id));

--- a/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
+++ b/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
@@ -17,10 +17,7 @@
 package com.ericsson.ei.waitlist;
 
 import com.ericsson.ei.jmespath.JmesPathInterface;
-import com.ericsson.ei.mongo.MongoCondition;
-import com.ericsson.ei.mongo.MongoDBHandler;
-import com.ericsson.ei.mongo.MongoQuery;
-import com.ericsson.ei.mongo.MongoStringQuery;
+import com.ericsson.ei.mongo.*;
 import com.ericsson.ei.rules.RulesObject;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.mongodb.BasicDBObject;
@@ -44,9 +41,6 @@ import java.util.List;
 @Component
 public class WaitListStorageHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(WaitListStorageHandler.class);
-    public static final String DOCUMENT_ID_KEY = "_id";
-    public static final String DOCUMENT_TIME_KEY = "Time";
-    public static final String DOCUMENT_EVENT_KEY = "Event";
 
     @Getter
     @Value("${waitlist.collection.name}")
@@ -110,10 +104,11 @@ public class WaitListStorageHandler {
 
     private BasicDBObject createWaitListDocument(String event, JsonNode id, Date date) {
         BasicDBObject document = new BasicDBObject();
-        document.put(DOCUMENT_ID_KEY, id.textValue());
-        document.put(DOCUMENT_TIME_KEY, date);
-        document.put(DOCUMENT_EVENT_KEY, event);
-        mongoDbHandler.createTTLIndex(databaseName, waitlistCollectionName, DOCUMENT_TIME_KEY, waitlistTtl);
+        document.put(MongoConstants.ID, id.textValue());
+        document.put(MongoConstants.TIME, date);
+        document.put(MongoConstants.EVENT, event);
+        mongoDbHandler.createTTLIndex(databaseName, waitlistCollectionName, MongoConstants.TIME,
+                waitlistTtl);
         return document;
     }
 

--- a/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
+++ b/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
@@ -101,8 +101,8 @@ public class ERQueryServiceTest extends Mockito {
     }
 
     public String buildUri() {
-        String uri = "";
-        uri += erQueryService.getEventRepositoryUrl().trim() + eventId + "?limit=" + limitParam + "&tree=" + isTree + "&levels=" + levels;
+        String uri = String.format("%s%s?limit=%s&tree=%s&levels=%s",
+                erQueryService.getEventRepositoryUrl().trim(), eventId, limitParam, isTree, levels);
         return uri;
     }
 }

--- a/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
+++ b/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
@@ -102,7 +102,7 @@ public class ERQueryServiceTest extends Mockito {
 
     public String buildUri() {
         String uri = "";
-        uri += erQueryService.getErBaseUrl().trim() + eventId + "?limit=" + limitParam + "&tree=" + isTree + "&levels=" + levels;
+        uri += erQueryService.getEventRepositoryUrl().trim() + eventId + "?limit=" + limitParam + "&tree=" + isTree + "&levels=" + levels;
         return uri;
     }
 }

--- a/src/test/java/com/ericsson/ei/flowtests/SingleEventAggregationTest.java
+++ b/src/test/java/com/ericsson/ei/flowtests/SingleEventAggregationTest.java
@@ -29,7 +29,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
 import org.apache.commons.io.FileUtils;
+import org.apache.http.Header;
 import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -93,11 +95,11 @@ public class SingleEventAggregationTest extends FlowTestBase {
 
     @Before
     public void before() throws PropertyNotFoundException, Exception {
-
+        Header[] headers = {};
         MockitoAnnotations.initMocks(this);
         upStreamEventsHandler.setEventRepositoryQueryService(erQueryService);
         when(erQueryService.getEventStreamDataById(anyString(), any(SearchOption.class), anyInt(), anyInt(),
-                anyBoolean())).thenReturn(null);
+                anyBoolean())).thenReturn(new ResponseEntity(500, "", headers));
         super.setFirstEventWaitTime(5000);
 
         try {

--- a/src/test/java/com/ericsson/ei/handlers/test/ObjectHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/handlers/test/ObjectHandlerTest.java
@@ -79,7 +79,7 @@ public class ObjectHandlerTest {
         objHandler.setEventToObjectMap(eventToObjectMapHandler);
         objHandler.setMongoDbHandler(mongoDBHandler);
         objHandler.setJmespathInterface(jmesPathInterface);
-        objHandler.setCollectionName(collectionName);
+        objHandler.setAggregationsCollectionName(collectionName);
         objHandler.setDatabaseName(dataBaseName);
         objHandler.setSubscriptionHandler(subscriptionHandlerMock);
 

--- a/src/test/java/com/ericsson/ei/notifications/InformSubscriberTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/InformSubscriberTest.java
@@ -132,15 +132,14 @@ public class InformSubscriberTest {
 
         informSubscriber.informSubscriber(aggregatedObject, restPostSubscriptionNode);
         // Should expect 1 tries to perform a HTTP request since AuthenticationException should
-        // ignore failAttempt.
+        // ignore notification.retry configuration.
         verify(httpRequest, times(1)).perform();
         // Should try to save failed notification to DB
         verify(mongoDBHandler, times(1)).insertDocument(any(), any(), any());
     }
 
     /**
-     * If sedning email is successfull then there should be no tries to save massed notification to
-     * DB.
+     * If sending email is successful, no failed notification should be stored in database.
      *
      * @throws Exception
      */
@@ -194,7 +193,7 @@ public class InformSubscriberTest {
     }
 
     /**
-     * Preperation before rest post subscription tests to create rest post subscription and stubb
+     * Preparation before rest post subscription tests to create rest post subscription and stubb
      * HttpRequest setters.
      *
      * @throws IOException
@@ -210,8 +209,8 @@ public class InformSubscriberTest {
         restPostSubscriptionObject.setAuthenticationType("NO_AUTH").setNotificationMeta("some_url");
         restPostSubscriptionNode = mapper.readTree(restPostSubscriptionObject.toString());
 
-        // Setting failAttempts to 3
-        informSubscriber.setFailAttempt(REST_POST_RETRIES);
+        // Setting retries to 3
+        informSubscriber.setNotificationRetry(REST_POST_RETRIES);
     }
 
     /**


### PR DESCRIPTION
### Applicable Issues

/information endpoint returns a json blob containing configuration for Eiffel Intelligence (see in Swagger UI or from command line how this can look like). This JSON model is based on variable names from ParseInstanceInfoEI class which did not reflect the recent changes in application.properties.


### Description of the Change
* Renamed variables to better match their property names.
* Improved some java doc/spelling here and there ...
* Avoided NullPointerExceptions thrown in SingleEventAggregationTest by setting mock to a value instead of null. In ERQueryService we always expect the response back from ER to contain a body and make no checks for this ... 
* Extracted hard coded values for MongoDB keys to constants in the Mongo package. (I didn't change the "Time" --> "time" key yet, since this also needs documentation changes)
* Use String.format to build ER url.

A lof of things can still be improved, but baby steps ... 😄 

### Alternate Designs

### Benefits
Cleaner result back from /information endpoint - with variable names matching their property names
Shorten test logs ...

### Possible Drawbacks

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
