### PR TITLE
Remove deprecated methods/annotations in SwaggerConfig and Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-sudo: required
-
+os: linux
 dist: xenial
-
 language: java
 
 services:

--- a/src/main/java/com/ericsson/ei/config/SwaggerConfig.java
+++ b/src/main/java/com/ericsson/ei/config/SwaggerConfig.java
@@ -36,7 +36,7 @@ public class SwaggerConfig {
 
     private static final String CONTACT_NAME = "Eiffel Intelligence Maintainers";
     private static final String CONTACT_URL = "https://github.com/eiffel-community/eiffel-intelligence";
-    private static final String CONTACT_EMAIL = "https://groups.google.com/forum/#!forum/eiffel-community";
+    private static final String CONTACT_EMAIL = "eiffel-community@googlegroups.com";
 
     @Autowired
     ParseInstanceInfoEI parseInstanceInfoEI;

--- a/src/main/java/com/ericsson/ei/config/SwaggerConfig.java
+++ b/src/main/java/com/ericsson/ei/config/SwaggerConfig.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -33,11 +34,15 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2
 public class SwaggerConfig {
 
+    private static final String CONTACT_NAME = "Eiffel Intelligence Maintainers";
+    private static final String CONTACT_URL = "https://github.com/eiffel-community/eiffel-intelligence";
+    private static final String CONTACT_EMAIL = "https://groups.google.com/forum/#!forum/eiffel-community";
+
     @Autowired
     ParseInstanceInfoEI parseInstanceInfoEI;
 
     @Bean
-    public Docket productApi() {
+    public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("com.ericsson.ei.controller"))
@@ -45,13 +50,14 @@ public class SwaggerConfig {
                 .build()
                 .apiInfo(metaData());
     }
-    @SuppressWarnings("deprecation")
+
     private ApiInfo metaData() {
         ApiInfo apiInfo = new ApiInfo(
                 "Eiffel Intelligence REST API",
                 "A real time data aggregation and analysis solution for Eiffel events.",
                 parseInstanceInfoEI.getVersion(),
-                "Terms of service","",
+                "Terms of service",
+                new Contact(CONTACT_NAME, CONTACT_URL, CONTACT_EMAIL),
                "Apache License Version 2.0",
                "https://www.apache.org/licenses/LICENSE-2.0");
         return apiInfo;


### PR DESCRIPTION

### Applicable Issues
Travis configuration showed warnings of deprecation in configuration
SwaggerConfig class contained use of deprecated methods, with SuppressWarning added

### Description of the Change
* Stop using deprecated constructor in Swagger ApiInfo and introduce Contact
* Remove (useless) sudo in travis configuration and add os tag


### Alternate Designs


### Benefits
Stop using deprecated methods ...

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
