### PR TITLE
Split surefire into a parallel and a sequential execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,6 +504,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <!-- Surefire tests are split into parallel and sequential tests.
+                     If the test is sensitive to run in parallel it should be
+                     excluded from that execution and moved into sequential. -->
                 <executions>
                     <execution>
                         <id>default-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
                 <version>${springBootVersion}</version>
             </plugin>
 
-            <!-- PhoenixNAP RAML Code Generator plugin used to generate sources 
+            <!-- PhoenixNAP RAML Code Generator plugin used to generate sources
                 from raml -->
             <plugin>
                 <groupId>com.phoenixnap.oss</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
                 <version>${springBootVersion}</version>
             </plugin>
 
-            <!-- PhoenixNAP RAML Code Generator plugin used to generate sources
+            <!-- PhoenixNAP RAML Code Generator plugin used to generate sources 
                 from raml -->
             <plugin>
                 <groupId>com.phoenixnap.oss</groupId>
@@ -504,22 +504,59 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
-                <configuration>
-                    <skipTests>${skipUTs}</skipTests>
-                    <forkCountTests>${forkCountTests}</forkCountTests>
-                    <forkCount>${forkCountTests}</forkCount>
-                    <reuseForks>true</reuseForks>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                        <exclude>${someModule.test.excludes}</exclude>
-                        <exclude>**/integrationtests/*</exclude>
-                    </excludes>
-                    <includes>
-                        <include>${someModule.test.includes}</include>
-                    </includes>
-                    <parallel>classes</parallel>
-                    <threadCount>5</threadCount>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>parallel-tests</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skipTests>${skipUTs}</skipTests>
+                            <forkCount>${forkCountTests}</forkCount>
+                            <reuseForks>true</reuseForks>
+                            <parallel>classes</parallel>
+                            <threadCount>5</threadCount>
+                            <includes>
+                                <include>${someModule.test.includes}</include>
+                            </includes>
+                            <excludes>
+                                <exclude>${someModule.test.excludes}</exclude>
+                                <exclude>**/*IT.java</exclude>
+                                <exclude>**/integrationtests/*</exclude>
+                                <exclude>**/TestTTLRunner.java</exclude>
+                                <exclude>**/TestSubscriptionNotificationRunner.java</exclude>
+                                <exclude>**/TestScalingAndFailoverRunner.java</exclude>
+                                <exclude>**/FlowTestTestExecution.java</exclude>
+                                <exclude>**/SingleEventAggregationTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>sequential-tests</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skipTests>${skipUTs}</skipTests>
+                            <reuseForks>false</reuseForks>
+                            <includes>
+                                <include>**/TestTTLRunner.java</include>
+                                <include>**/TestSubscriptionNotificationRunner.java</include>
+                                <include>**/TestScalingAndFailoverRunner.java</include>
+                                <include>**/FlowTestTestExecution.java</include>
+                                <include>**/SingleEventAggregationTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
Tests are having a very high failure rate.

### Description of the Change
This little fix splits the surefire plugin into two separate executions. The parallel one runs first with the tests that have no issues running at the same time and the sequential one runs afterwards with tests that are sensitive to parallel execution.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @Christoffer-Cortes 
