### PR TITLE
fix by replacing id with _id

### DIFF
--- a/src/main/java/com/ericsson/ei/queryservice/ProcessAggregatedObject.java
+++ b/src/main/java/com/ericsson/ei/queryservice/ProcessAggregatedObject.java
@@ -72,7 +72,7 @@ public class ProcessAggregatedObject {
      * @return ArrayList
      */
     public ArrayList<String> getAggregatedObjectByTemplateName(String templateName) {
-        String queryString = "{\"id\": /.*" + templateName + "/}";
+        String queryString = "{\"_id\": /.*" + templateName + "/}";
         MongoQuery query = new MongoStringQuery(queryString);
         LOGGER.debug("The JSON query is: {}", query);
         return mongoDBHandler.find(aggregationDataBaseName, aggregationCollectionName, query);
@@ -86,7 +86,7 @@ public class ProcessAggregatedObject {
      * @return boolean
      */
     public boolean deleteAggregatedObject(String templateName) {
-        String queryString = "{\"id\": /.*" + templateName + "/}";
+        String queryString = "{\"_id\": /.*" + templateName + "/}";
         MongoQuery query = new MongoStringQuery(queryString);
         LOGGER.debug("The JSON query for deleting aggregated object is: {}", query);
         return mongoDBHandler.dropDocument(aggregationDataBaseName, aggregationCollectionName, query);


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->


### Applicable Issues
Closes https://github.com/eiffel-community/eiffel-intelligence/issues/441

This is because Eiffel Intelligence doesn't find the resulting aggregation from the database.
The key to search for should be "_id" not "id" - since we can't expect all and every custom rule set to put an "id" in the root of the aggregation.

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
