### PR TITLE
Waitlist queue is now created and add support for multiple binding keys

### DIFF
--- a/src/functionaltests/java/com/ericsson/ei/rabbitmq/RabbitMQTestConnectionSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/rabbitmq/RabbitMQTestConnectionSteps.java
@@ -145,7 +145,7 @@ public class RabbitMQTestConnectionSteps extends FunctionalTestBase {
         admin.getQueueProperties(queueName);
         RabbitTemplate rabbitTemplate = admin.getRabbitTemplate();
         rabbitTemplate.setExchange(exchangeName);
-        rabbitTemplate.setRoutingKey(rmqProperties.getBindingKey());
+        rabbitTemplate.setRoutingKey(RMQProperties.WAITLIST_BINDING_KEY);
         rabbitTemplate.setQueue(queueName);
         return admin;
     }

--- a/src/functionaltests/java/com/ericsson/ei/rabbitmq/configuration/RabbitMQConfigurationTestRunner.java
+++ b/src/functionaltests/java/com/ericsson/ei/rabbitmq/configuration/RabbitMQConfigurationTestRunner.java
@@ -1,0 +1,13 @@
+package com.ericsson.ei.rabbitmq.configuration;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "src/functionaltests/resources/features/rabbitMQConfiguration.feature", glue = {
+        "com.ericsson.ei.rabbitmq.configuration" }, plugin = { "html:target/cucumber-reports/RabbitMQTestConfigurationRunner" })
+public class RabbitMQConfigurationTestRunner {
+
+}

--- a/src/functionaltests/java/com/ericsson/ei/rabbitmq/connection/RabbitMQTestConnectionRunner.java
+++ b/src/functionaltests/java/com/ericsson/ei/rabbitmq/connection/RabbitMQTestConnectionRunner.java
@@ -1,4 +1,4 @@
-package com.ericsson.ei.rabbitmq;
+package com.ericsson.ei.rabbitmq.connection;
 
 import org.junit.runner.RunWith;
 
@@ -7,7 +7,7 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "src/functionaltests/resources/features/rabbitMQTestConnection.feature", glue = {
-        "com.ericsson.ei.rabbitmq" }, plugin = { "html:target/cucumber-reports/RabbitMQTestConnectionRunner" })
+        "com.ericsson.ei.rabbitmq.connection" }, plugin = { "html:target/cucumber-reports/RabbitMQTestConnectionRunner" })
 public class RabbitMQTestConnectionRunner {
 
 }

--- a/src/functionaltests/java/com/ericsson/ei/rabbitmq/connection/RabbitMQTestConnectionSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/rabbitmq/connection/RabbitMQTestConnectionSteps.java
@@ -1,0 +1,153 @@
+package com.ericsson.ei.rabbitmq.connection;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Ignore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.core.RabbitTemplate.ConfirmCallback;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.support.CorrelationData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.SocketUtils;
+
+import com.ericsson.ei.handlers.EventHandler;
+import com.ericsson.ei.handlers.RMQHandler;
+import com.ericsson.ei.handlers.RMQProperties;
+import com.ericsson.ei.utils.AMQPBrokerManager;
+import com.ericsson.ei.utils.FunctionalTestBase;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+
+@Ignore
+@TestPropertySource(properties = {
+        "spring.data.mongodb.database: RabbitMQTestConnectionSteps",
+        "failed.notifications.collection.name: RabbitMQTestConnectionSteps-failedNotifications",
+        "rabbitmq.exchange.name: RabbitMQTestConnectionSteps-exchange",
+        "rabbitmq.queue.suffix: RabbitMQTestConnectionSteps" })
+public class RabbitMQTestConnectionSteps extends FunctionalTestBase {
+
+    @Value("${rabbitmq.port}")
+    private String rabbitMQPort;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMQTestConnectionSteps.class);
+    private static final String EIFFEL_EVENTS = "src/functionaltests/resources/eiffel_events_for_thread_testing.json";
+
+    private AMQPBrokerManager amqpBroker;
+
+    @Autowired
+    @Qualifier("bindToQueueForRecentEvents")
+    SimpleMessageListenerContainer container;
+
+    @Autowired
+    EventHandler eventHandler;
+
+    @Given("^We are connected to message bus$")
+    public void connect_to_message_bus() throws Exception {
+        int port = SocketUtils.findAvailableTcpPort();
+        String config = "src/functionaltests/resources/configs/qpidConfig.json";
+        File qpidConfig = new File(config);
+        amqpBroker = new AMQPBrokerManager(qpidConfig.getAbsolutePath(), port);
+        amqpBroker.startBroker();
+
+        RMQHandler rmqHandler = eventManager.getRmqHandler();
+        RMQProperties rmqProperties = rmqHandler.getRmqProperties();
+        rmqProperties.setPort(port);
+        rmqHandler.connectionFactory();
+        rmqHandler.getCachingConnectionFactory().createConnection();
+
+        RabbitAdmin rabbitAdmin = createExchange(rmqHandler);
+        RabbitTemplate rabbitTemplate = rabbitAdmin.getRabbitTemplate();
+        rabbitTemplate.setConfirmCallback(new ConfirmCallback() {
+            @Override
+            public void confirm(CorrelationData correlationData, boolean ack, String cause) {
+                LOGGER.info("Received confirm with result : {}", ack);
+            }
+        });
+
+        rmqHandler.setRabbitTemplate(rabbitTemplate);
+        rmqHandler.getContainer().setRabbitAdmin(rabbitAdmin);
+        rmqHandler.getContainer().setConnectionFactory(rmqHandler.getCachingConnectionFactory());
+        rmqHandler.getContainer().setQueueNames(rmqProperties.getQueueName());
+        assertEquals("Expected message bus to be up", true, amqpBroker.isRunning);
+    }
+
+    @When("^Message bus goes down$")
+    public void message_bus_goes_down() {
+        LOGGER.debug("Shutting down message bus");
+        amqpBroker.stopBroker();
+        assertEquals("Expected message bus to be down", false, amqpBroker.isRunning);
+    }
+
+    @When("^Message bus is restarted$")
+    public void message_bus_is_restarted() throws Exception {
+        amqpBroker.startBroker();
+        createExchange(eventManager.getRmqHandler());
+    }
+
+    @Then("^I can send events which are put in the waitlist$")
+    public void can_send_events_which_are_put_in_the_waitlist() throws Exception {
+        LOGGER.debug("Sending eiffel events");
+        int waitListSize = 0;
+        List<String> eventNames = getEventNamesToSend();
+        long maxTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+
+        while (waitListSize != 4 && maxTime > System.currentTimeMillis()) {
+            eventManager.sendEiffelEvents(EIFFEL_EVENTS, eventNames);
+            TimeUnit.SECONDS.sleep(2);
+            waitListSize = dbManager.waitListSize();
+        }
+        assertEquals(4, waitListSize);
+    }
+
+    /**
+     * This method collects all the event names of events we will send to the
+     * message bus.
+     */
+    protected List<String> getEventNamesToSend() {
+        List<String> eventNames = new ArrayList<>();
+        eventNames.add("event_EiffelConfidenceLevelModifiedEvent_3_2");
+        eventNames.add("event_EiffelArtifactPublishedEvent_3");
+        eventNames.add("event_EiffelTestCaseTriggeredEvent_3");
+        eventNames.add("event_EiffelTestCaseStartedEvent_3");
+        return eventNames;
+    }
+
+    private RabbitAdmin createExchange(final RMQHandler rmqHandler) {
+        RMQProperties rmqProperties = rmqHandler.getRmqProperties();
+        final String exchangeName = rmqProperties.getExchangeName();
+        final String queueName = rmqProperties.getQueueName();
+        final CachingConnectionFactory ccf = rmqHandler.getCachingConnectionFactory();
+        LOGGER.info("Creating exchange: {} and queue: {}", exchangeName, queueName);
+        RabbitAdmin admin = new RabbitAdmin(ccf);
+        Queue queue = new Queue(queueName, true);
+        admin.declareQueue(queue);
+        final TopicExchange exchange = new TopicExchange(exchangeName, true, false);
+        admin.declareExchange(exchange);
+        admin.declareBinding(BindingBuilder.bind(queue).to(exchange).with("#"));
+        admin.initialize();
+        admin.getQueueProperties(queueName);
+        RabbitTemplate rabbitTemplate = admin.getRabbitTemplate();
+        rabbitTemplate.setExchange(exchangeName);
+        rabbitTemplate.setRoutingKey(RMQProperties.WAITLIST_BINDING_KEY);
+        rabbitTemplate.setQueue(queueName);
+        return admin;
+    }
+
+}

--- a/src/functionaltests/java/com/ericsson/ei/threadingAndWaitlistRepeat/ThreadingAndWaitlistRepeatSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/threadingAndWaitlistRepeat/ThreadingAndWaitlistRepeatSteps.java
@@ -107,26 +107,6 @@ public class ThreadingAndWaitlistRepeatSteps extends FunctionalTestBase {
                 dbManager.waitListSize());
     }
 
-    @Then("^correct amount of threads should be spawned$")
-    public void correct_amount_of_threads_should_be_spawned() throws Throwable {
-        List<String> threadsSpawned = new ArrayList<>();
-        String port = environment.getProperty("local.server.port");
-        String eventHandlerThreadNamePattern = String.format("EventHandler-(\\d+)-%s", port);
-        Pattern pattern = Pattern.compile(eventHandlerThreadNamePattern);
-
-        Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
-        Thread[] threadArray = threadSet.toArray(new Thread[threadSet.size()]);
-        for (Thread thread : threadArray) {
-            Matcher matcher = pattern.matcher(thread.getName());
-            if (matcher.find() && !matcher.group(1).equals("")) {
-                if (!threadsSpawned.contains(matcher.group(1))) {
-                    threadsSpawned.add(matcher.group(1));
-                }
-            }
-        }
-        assertEquals(getEventNamesToSend().size() - queueCapacity, threadsSpawned.size());
-    }
-
     @Then("^after the time to live has ended, the waitlist should be empty$")
     public void after_the_time_to_live_has_ended_the_waitlist_should_be_empty() throws Throwable {
         long stopTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(waitlistTtl + 60);

--- a/src/functionaltests/java/com/ericsson/ei/threadingAndWaitlistRepeat/ThreadingAndWaitlistRepeatSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/threadingAndWaitlistRepeat/ThreadingAndWaitlistRepeatSteps.java
@@ -5,15 +5,11 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 
 import com.ericsson.ei.handlers.EventToObjectMapHandler;
@@ -44,15 +40,6 @@ public class ThreadingAndWaitlistRepeatSteps extends FunctionalTestBase {
     private static final String EIFFEL_EVENTS_JSON_PATH = "src/functionaltests/resources/eiffel_events_for_thread_testing.json";
     private static final String ID_RULE = "{" + "\"IdRule\": \"meta.id\"" + "}";
 
-    @Autowired
-    private Environment environment;
-
-    @Value("${threads.core.pool.size}")
-    private int corePoolSize;
-    @Value("${threads.queue.capacity}")
-    private int queueCapacity;
-    @Value("${threads.max.pool.size}")
-    private int maxPoolSize;
     @Value("${waitlist.collection.ttl}")
     private int waitlistTtl;
 

--- a/src/functionaltests/resources/features/rabbitMQConfiguration.feature
+++ b/src/functionaltests/resources/features/rabbitMQConfiguration.feature
@@ -1,0 +1,8 @@
+@RabbitMQConfiguration
+Feature: Test Rabbit MQ Configuration
+
+  @RabbitMQConfigurationMultipleRoutingKeysScenario
+  Scenario: Test that aggregations are done when events are sent with different routing keys
+    Given We are connected to message bus
+    When events are published using different routing keys
+    Then an aggregated object should be created

--- a/src/functionaltests/resources/features/threadingAndWaitlistRepeat.feature
+++ b/src/functionaltests/resources/features/threadingAndWaitlistRepeat.feature
@@ -7,6 +7,5 @@ Feature: Test Threading and Waitlist Repeat
 	Then waitlist should not be empty
 	And no event is aggregated
 	And event-to-object-map is manipulated to include the sent events
-	And when waitlist has resent events they should have been deleted        
-	And correct amount of threads should be spawned
+	And when waitlist has resent events they should have been deleted
 	And after the time to live has ended, the waitlist should be empty

--- a/src/main/java/com/ericsson/ei/handlers/RMQProperties.java
+++ b/src/main/java/com/ericsson/ei/handlers/RMQProperties.java
@@ -81,12 +81,14 @@ public class RMQProperties {
     @Getter
     @Setter
     @Value("${rabbitmq.binding.key}")
-    private String bindingKey;
+    private String bindingKeys;
 
     @Getter
     @Setter
     @Value("${rabbitmq.queue.suffix}")
     private String queueSuffix;
+
+    public static final String WAITLIST_BINDING_KEY = "eiffel-intelligence.waitlist";
 
     public String getQueueName() {
         final String durableName = this.queueDurable ? "durable" : "transient";

--- a/src/test/java/com/ericsson/ei/handlers/test/RmqPropertiesTest.java
+++ b/src/test/java/com/ericsson/ei/handlers/test/RmqPropertiesTest.java
@@ -42,7 +42,7 @@ public class RmqPropertiesTest {
     private Integer port = 5672;
     private String domainId = "EN1";
     private String componentName = "eiffelintelligence";
-    private String bindingKey = "#";
+    private String bindingKeys = "#";
     private String queueSuffix = "RmqHandlerTest";
     private String queueName = "EN1.eiffelintelligence.RmqHandlerTest.durable";
     private String waitlistQueueName = "EN1.eiffelintelligence.RmqHandlerTest.durable.waitlist";
@@ -82,7 +82,7 @@ public class RmqPropertiesTest {
 
     @Test
     public void getRoutingKeyTest() {
-        assertThat(rmqProperties.getBindingKey(), is(equalTo(bindingKey)));
+        assertThat(rmqProperties.getBindingKeys(), is(equalTo(bindingKeys)));
     }
 
     @Test

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -180,13 +180,15 @@ The second property **spring.data.mongodb.database** defines a name for the data
 You can configure the RabbitMQ settings using the rabbitmq.* properties.
 Most of the properties should be familiar but a few may need some further explanation.
 The rabbitmq.domain.id, rabbitmq.component.name, rabbitmq.queue.suffix and rabbitmq.queue.durable
-are used to build the queue name on which Eiffel Intelligence listens for messages.
+are used to build the queue name on which Eiffel Intelligence listens for outside messages.
+Multiple routing keys can be defined for this queue with the rabbitmq.binding.key property by writing
+them one after the other in a comma separated string e.g. routing-key1, routing-key2, ... etc.
 An internal waitlist queue is also created that uses all of the previously mentioned properties but also
 attaches the rabbitmq.waitlist.queue.suffix property at the end of the name.
-This queue does not get the routing key binding from the rabbitmq.binding.key property and is only meant for
+This queue does not get the routing key bindings from the rabbitmq.binding.key property and is only meant for
 sending and consuming messages by Eiffel Intelligence.
 It instead uses the non-configurable routing key "eiffel-intelligence.waitlist".
-The rabbitmq.tls.version property specifies the security protocol and you can find valid names
+The rabbitmq.tlsVersion property specifies the security protocol and you can find valid names
 [here](https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SSLContext)
 
 * rabbitmq.host

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -179,8 +179,10 @@ The second property **spring.data.mongodb.database** defines a name for the data
 
 You can configure the RabbitMQ settings using the rabbitmq.* properties.
 Most of the properties should be familiar but a few may need some further explanation.
-The rabbitmq.domain.id, rabbitmq.component.name and rabbitmq.queue.suffix are used to build
-the queue name on which Eiffel Intelligence listens for messages.
+The rabbitmq.domain.id, rabbitmq.component.name, rabbitmq.queue.suffix and rabbitmq.queue.durable
+are used to build the queue name on which Eiffel Intelligence listens for messages.
+The waitlist queue also attaches the rabbitmq.waitlist.queue.suffix property and all of the previously
+mentioned properties.
 The rabbitmq.tls.version property specifies the security protocol and you can find valid names
 [here](https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SSLContext)
 

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -188,7 +188,7 @@ attaches the rabbitmq.waitlist.queue.suffix property at the end of the name.
 This queue does not get the routing key bindings from the rabbitmq.binding.key property and is only meant for
 sending and consuming messages by Eiffel Intelligence.
 It instead uses the non-configurable routing key "eiffel-intelligence.waitlist".
-The rabbitmq.tlsVersion property specifies the security protocol and you can find valid names
+The rabbitmq.tls.version property specifies the security protocol and you can find valid names
 [here](https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SSLContext)
 
 * rabbitmq.host

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -181,8 +181,11 @@ You can configure the RabbitMQ settings using the rabbitmq.* properties.
 Most of the properties should be familiar but a few may need some further explanation.
 The rabbitmq.domain.id, rabbitmq.component.name, rabbitmq.queue.suffix and rabbitmq.queue.durable
 are used to build the queue name on which Eiffel Intelligence listens for messages.
-The waitlist queue also attaches the rabbitmq.waitlist.queue.suffix property and all of the previously
-mentioned properties.
+An internal waitlist queue is also created that uses all of the previously mentioned properties but also
+attaches the rabbitmq.waitlist.queue.suffix property at the end of the name.
+This queue does not get the routing key binding from the rabbitmq.binding.key property and is only meant for
+sending and consuming messages by Eiffel Intelligence.
+It instead uses the non-configurable routing key "eiffel-intelligence.waitlist".
 The rabbitmq.tls.version property specifies the security protocol and you can find valid names
 [here](https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SSLContext)
 


### PR DESCRIPTION
### Applicable Issues
Closes https://github.com/eiffel-community/eiffel-intelligence/issues/414

### Description of the Change
Added support for multiple routing key bindings in RabbitMQ. The same rabbitmq.binding.key property is used as a comma separated string e.g. routing-key1, routing-key2.
The internal waitlist will now also publish events using the routing key eiffel-intelligence.waitlist.
This also means that Eiffel Intelligence now listens to events sent using the mentioned routing key.
The waitlist queue is now actually created and internal events are sent on that queue.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
This makes it configurable to set up bindings towards several "domains".

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @Christoffer-Cortes 
