### PR TITLE
Remove non official Eiffel events from all events rules

### DIFF
--- a/src/main/resources/rules/AllEventsRules-Eiffel-Agen-Version.json
+++ b/src/main/resources/rules/AllEventsRules-Eiffel-Agen-Version.json
@@ -41,36 +41,6 @@
   },
   {
     "TemplateName":"Event_copy",
-    "Type":"EiffelAlertAcknowledgedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelAlertCeasedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelAlertRaisedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
     "Type":"EiffelAnnouncementPublishedEvent",
     "TypeRule": "meta.type",
     "IdRule": "meta.id",
@@ -82,16 +52,6 @@
   {
     "TemplateName":"Event_copy",
     "Type":"EiffelArtifactCreatedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelArtifactDeployedEvent",
     "TypeRule": "meta.type",
     "IdRule": "meta.id",
     "StartEvent": "YES",
@@ -162,65 +122,6 @@
   {
     "TemplateName":"Event_copy",
     "Type":"EiffelIssueVerifiedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },{
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceAllocatedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceDeployedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceDiscontinuedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceReturnedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceStartedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceStoppedEvent",
     "TypeRule": "meta.type",
     "IdRule": "meta.id",
     "StartEvent": "YES",

--- a/src/main/resources/rules/AllEventsRules-Eiffel-Toulouse-Version.json
+++ b/src/main/resources/rules/AllEventsRules-Eiffel-Toulouse-Version.json
@@ -41,36 +41,6 @@
   },
   {
     "TemplateName":"Event_copy",
-    "Type":"EiffelAlertAcknowledgedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelAlertCeasedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelAlertRaisedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
     "Type":"EiffelAnnouncementPublishedEvent",
     "TypeRule": "meta.type",
     "IdRule": "meta.id",
@@ -82,16 +52,6 @@
   {
     "TemplateName":"Event_copy",
     "Type":"EiffelArtifactCreatedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelArtifactDeployedEvent",
     "TypeRule": "meta.type",
     "IdRule": "meta.id",
     "StartEvent": "YES",
@@ -162,65 +122,6 @@
   {
     "TemplateName":"Event_copy",
     "Type":"EiffelIssueVerifiedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },{
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceAllocatedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceDeployedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceDiscontinuedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceReturnedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceStartedEvent",
-    "TypeRule": "meta.type",
-    "IdRule": "meta.id",
-    "StartEvent": "YES",
-    "IdentifyRules" : "[meta.id]",
-    "MatchIdRules": {"_id": "%IdentifyRulesEventId%"},
-    "ExtractionRules" : "@"
-  },
-  {
-    "TemplateName":"Event_copy",
-    "Type":"EiffelServiceStoppedEvent",
     "TypeRule": "meta.type",
     "IdRule": "meta.id",
     "StartEvent": "YES",

--- a/wiki/example-rules.md
+++ b/wiki/example-rules.md
@@ -34,7 +34,7 @@ In the example "[all event rules](src/main/resources/rules/AllEventsRules-Eiffel
 no aggregation is defined. Eiffel Intelligence will simply listen to the
 Eiffel events listed, and put them as is in the database.
 Each Eiffel event will become a separate object/document in the database,
-independent of, if they are linked together or not.
+regardless of whether the events are linked together or not.
 
 These rules are **not meant for production use**, since the database will become
 a copy of any other storage implementation for Eiffel events. These example

--- a/wiki/example-rules.md
+++ b/wiki/example-rules.md
@@ -1,14 +1,13 @@
 # Example Rules
 
-We have created some example rules that represent use cases which triggered 
-the development of Eiffel Intelligence. The files containing the rules 
+We have created some example rules that represent use cases which triggered
+the development of Eiffel Intelligence. The files containing the rules
 can be found [**here**](../src/main/resources/rules).
 
-We have also illustrated the Eiffel event flows which these example rules 
-need, to perform the aggregation. The illustrations contain the events 
-and how they are linked together. 
-Any upstream events linked from this are looked up from ER if HistoryRules 
-are defined. Following events in the chain which are linked back to the 
+We have also illustrated the Eiffel event flows which these example rules
+need, to perform the aggregation. The illustrations contain the events
+and how they are linked together. Any upstream events linked from this are looked up from ER if HistoryRules
+are defined. Following events in the chain which are linked back to the
 ArtifactCreated event will be included in the aggregation, according to
 the rules.
 
@@ -16,16 +15,28 @@ the rules.
 The start event for this flow is the ArtifactCreated (ArtC2) event.
 
 <img src="images/ArtifactRules.png">
-</img>
+
 
 ## Flow with the Events Required for SourceChange Object Flow
 The start event for this flow is the SourceChangeSubmitted (SCS1) event.
 
 <img src="images/SourceChangeRules.png">
-</img>
+
 
 ## Flow with the Events Required for TestExecution Object Flow
 The start event for this flow is the ActivityTriggered (ActT) event.
 
 <img src="images/TestExecutionRules.png">
-</img>
+
+
+## All Events Rules
+In the example "[all event rules](src/main/resources/rules/AllEventsRules-Eiffel-Agen-Version.json)"
+no aggregation is defined. Eiffel Intelligence will simply listen to the
+Eiffel events listed, and put them as is in the database.
+Each Eiffel event will become a separate object/document in the database,
+independent of, if they are linked together or not.
+
+These rules are **not meant for production use**, since the database will become
+a copy of any other storage implementation for Eiffel events. These example
+rules can be used as a base to further extend, and could be a good starting
+point when testing out new rules in Eiffel Intelligence.


### PR DESCRIPTION

### Applicable Issues
The example rules "All event rules" contained Eiffel events which is not included in the official protocol. And it is not mentioned in the documentation anywhere how the "All event rules" works (compared to the other example rules, these do not define any aggregation of multiple events, but rather stores every event as is). 

### Description of the Change
Added some clarifying text that the existing example rules called "All events rules", does not actually perform any aggregation on any Eiffel events.


### Alternate Designs

### Benefits
A word of caution is added in the documentation to not use these rules in production for agrgegation purposes.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
