### PR TITLE
3.x Use waitlist queue name as routing key

### DIFF
--- a/src/functionaltests/java/com/ericsson/ei/rabbitmq/connection/RabbitMQTestConnectionSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/rabbitmq/connection/RabbitMQTestConnectionSteps.java
@@ -145,7 +145,7 @@ public class RabbitMQTestConnectionSteps extends FunctionalTestBase {
         admin.getQueueProperties(queueName);
         RabbitTemplate rabbitTemplate = admin.getRabbitTemplate();
         rabbitTemplate.setExchange(exchangeName);
-        rabbitTemplate.setRoutingKey(RMQProperties.WAITLIST_BINDING_KEY);
+        rabbitTemplate.setRoutingKey(rmqProperties.getWaitlistQueueName());
         rabbitTemplate.setQueue(queueName);
         return admin;
     }

--- a/src/main/java/com/ericsson/ei/handlers/RMQHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/RMQHandler.java
@@ -122,7 +122,7 @@ public class RMQHandler {
 
             rabbitTemplate.setQueue(rmqProperties.getWaitlistQueueName());
             rabbitTemplate.setExchange(rmqProperties.getExchangeName());
-            rabbitTemplate.setRoutingKey(RMQProperties.WAITLIST_BINDING_KEY);
+            rabbitTemplate.setRoutingKey(rmqProperties.getWaitlistQueueName());
             rabbitTemplate.setConfirmCallback(new ConfirmCallback() {
                 @Override
                 public void confirm(CorrelationData correlationData, boolean ack, String cause) {
@@ -164,7 +164,7 @@ public class RMQHandler {
 
     @Bean
     protected Binding binding() {
-        return BindingBuilder.bind(internalQueue()).to(exchange()).with(RMQProperties.WAITLIST_BINDING_KEY);
+        return BindingBuilder.bind(internalQueue()).to(exchange()).with(rmqProperties.getWaitlistQueueName());
     }
 
     @Bean

--- a/src/main/java/com/ericsson/ei/handlers/RMQProperties.java
+++ b/src/main/java/com/ericsson/ei/handlers/RMQProperties.java
@@ -88,7 +88,6 @@ public class RMQProperties {
     @Value("${rabbitmq.queue.suffix}")
     private String queueSuffix;
 
-    public static final String WAITLIST_BINDING_KEY = "eiffel-intelligence.waitlist";
 
     public String getQueueName() {
         final String durableName = this.queueDurable ? "durable" : "transient";

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -187,7 +187,7 @@ An internal waitlist queue is also created that uses all of the previously menti
 attaches the rabbitmq.waitlist.queue.suffix property at the end of the name.
 This queue does not get the routing key bindings from the rabbitmq.binding.key property and is only meant for
 sending and consuming messages by Eiffel Intelligence.
-It instead uses the non-configurable routing key "eiffel-intelligence.waitlist".
+It instead uses the full name of the waitlist queue as a routing key.
 The rabbitmq.tls.version property specifies the security protocol and you can find valid names
 [here](https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SSLContext)
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
Internal waitlist queue now binds to the exchange using its own name.
That means if the waitlist name is "ei.domain001.my-rules.waitlist" then the binding key will also be that same name.
This is to fix an issue with multiple EI instances listening for events over the same exchange.
With a fixed binding key on all instances they would each get a copy of the event into their waitlist queue even though the event was only meant for one of the queues.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @Christoffer-Cortes 
