### PR TITLE
Added default values in ParseInstanceInfo class for subscription

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.ericsson</groupId>
     <artifactId>eiffel-intelligence</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <packaging>war</packaging>
 
     <parent>

--- a/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
+++ b/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
@@ -195,15 +195,15 @@ public class ParseInstanceInfoEI {
         private int eventHandlerMaxPoolSize;
 
         @Getter
-        @Value("${subscription-handler.threads.corePoolSize}")
+        @Value("${subscription-handler.threads.corePoolSize:100}")
         private int subscriptionHandlerCorePoolSize;
 
         @Getter
-        @Value("${subscription-handler.threads.queueCapacity}")
+        @Value("${subscription-handler.threads.queueCapacity:5000}")
         private int subscriptionHandlerQueueCapacity;
 
         @Getter
-        @Value("${subscription-handler.threads.maxPoolSize}")
+        @Value("${subscription-handler.threads.maxPoolSize:150}")
         private int subscriptionHandlerMaxPoolSize;
     }
 }


### PR DESCRIPTION
- Added default values for subsciption thread handling in
ParseInstanceInfo class
- Updated pom.xml file with a new version

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
After the fix for subscription thread, if the default values are not provided in the application.properties the EI backed fails to start because of the missing default values in ParseInstanceInfo class.

### Description of the Change
Added default values in the ParseInstanceInfo class so that the application can start even without providing the subscription-thread.* values in applicaion.properties.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
SignedBy : @SantoshNC68 


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
