### PR TITLE
Change Event and Aggreagations threads to use only one threadpool

### DIFF
--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.ericsson.ei.mongo.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 import org.slf4j.Logger;
@@ -274,6 +275,7 @@ public class ObjectHandler {
      *
      * @return ttl Integer value representing time to live for documents
      */
+    @JsonIgnore
     public int getTtl() {
         int ttl = 0;
         if (StringUtils.isNotEmpty(aggregationsTtl)) {

--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.ericsson.ei.mongo.*;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 import org.slf4j.Logger;
@@ -59,10 +58,9 @@ public class ObjectHandler {
     @Value("${spring.data.mongodb.database}")
     private String databaseName;
 
-    @JsonIgnore
     @Getter
     @Value("${aggregations.collection.ttl}")
-    private String aggregationsTtlConfig;
+    private String aggregationsTtl;
 
     @Setter
     @Autowired
@@ -100,9 +98,9 @@ public class ObjectHandler {
         LOGGER.debug("ObjectHandler: Aggregated Object document to be inserted: {}",
                 document.toString());
 
-        if (getAggregationsTtl() > 0) {
+        if (getTtl() > 0) {
             mongoDbHandler.createTTLIndex(databaseName, aggregationsCollectionName,
-                    MongoConstants.TIME, getAggregationsTtl());
+                    MongoConstants.TIME, getTtl());
         }
 
         mongoDbHandler.insertDocument(databaseName, aggregationsCollectionName, document.toString());
@@ -199,7 +197,7 @@ public class ObjectHandler {
         BasicDBObject document = BasicDBObject.parse(object);
         document.put(MongoConstants.ID, id);
         try {
-            if (getAggregationsTtl() > 0) {
+            if (getTtl() > 0) {
                 document.put(MongoConstants.TIME, DateUtils.getDate());
             }
         } catch (ParseException e) {
@@ -276,16 +274,16 @@ public class ObjectHandler {
      *
      * @return ttl Integer value representing time to live for documents
      */
-    public int getAggregationsTtl() {
-        int aggregationsTtl = 0;
-        if (StringUtils.isNotEmpty(aggregationsTtlConfig)) {
+    public int getTtl() {
+        int ttl = 0;
+        if (StringUtils.isNotEmpty(aggregationsTtl)) {
             try {
-                aggregationsTtl = Integer.parseInt(aggregationsTtlConfig);
+                ttl = Integer.parseInt(aggregationsTtl);
             } catch (NumberFormatException e) {
                 LOGGER.error("Failed to parse TTL value.", e);
             }
         }
-        return aggregationsTtl;
+        return ttl;
     }
 
     private boolean isInvalidId(String id) {

--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.ericsson.ei.mongo.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 import org.slf4j.Logger;
@@ -58,6 +59,7 @@ public class ObjectHandler {
     @Value("${spring.data.mongodb.database}")
     private String databaseName;
 
+    @JsonIgnore
     @Getter
     @Value("${aggregations.collection.ttl}")
     private String aggregationsTtl;

--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -62,7 +62,7 @@ public class ObjectHandler {
     @JsonIgnore
     @Getter
     @Value("${aggregations.collection.ttl}")
-    private String aggregationsTtl;
+    private String aggregationsTtlConfig;
 
     @Setter
     @Autowired
@@ -100,9 +100,9 @@ public class ObjectHandler {
         LOGGER.debug("ObjectHandler: Aggregated Object document to be inserted: {}",
                 document.toString());
 
-        if (getTtl() > 0) {
+        if (getAggregationsTtl() > 0) {
             mongoDbHandler.createTTLIndex(databaseName, aggregationsCollectionName,
-                    MongoConstants.TIME, getTtl());
+                    MongoConstants.TIME, getAggregationsTtl());
         }
 
         mongoDbHandler.insertDocument(databaseName, aggregationsCollectionName, document.toString());
@@ -199,7 +199,7 @@ public class ObjectHandler {
         BasicDBObject document = BasicDBObject.parse(object);
         document.put(MongoConstants.ID, id);
         try {
-            if (getTtl() > 0) {
+            if (getAggregationsTtl() > 0) {
                 document.put(MongoConstants.TIME, DateUtils.getDate());
             }
         } catch (ParseException e) {
@@ -276,16 +276,16 @@ public class ObjectHandler {
      *
      * @return ttl Integer value representing time to live for documents
      */
-    public int getTtl() {
-        int ttl = 0;
-        if (StringUtils.isNotEmpty(aggregationsTtl)) {
+    public int getAggregationsTtl() {
+        int aggregationsTtl = 0;
+        if (StringUtils.isNotEmpty(aggregationsTtlConfig)) {
             try {
-                ttl = Integer.parseInt(aggregationsTtl);
+                aggregationsTtl = Integer.parseInt(aggregationsTtlConfig);
             } catch (NumberFormatException e) {
                 LOGGER.error("Failed to parse TTL value.", e);
             }
         }
-        return ttl;
+        return aggregationsTtl;
     }
 
     private boolean isInvalidId(String id) {

--- a/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
@@ -392,8 +392,7 @@ public class MongoDBHandler {
         } catch (MongoInterruptedException | MongoSocketReadException | MongoSocketWriteException
                 | MongoCommandException | IllegalStateException e) {
             String message = String.format("Failed to get Mongo collection list, Reason: %s",
-                    e.getMessage());
-            closeMongoDbConnection();
+                    e.getMessage()); 
             throw new MongoClientException(message, e);
         }
     }

--- a/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
@@ -434,11 +434,4 @@ public class MongoDBHandler {
             throw new MongoClientException(message, e);
         }
     }
-
-    private void closeMongoDbConnection() {
-        if (mongoClient != null) {
-            mongoClient.close();
-        }
-        mongoClient = null;
-    }
 }

--- a/src/main/java/com/ericsson/ei/subscription/SubscriptionHandler.java
+++ b/src/main/java/com/ericsson/ei/subscription/SubscriptionHandler.java
@@ -74,11 +74,11 @@ public class SubscriptionHandler {
      */
     public void checkSubscriptionForObject(final String aggregatedObject,
                                            final String id) {
-            List<String> subscriptions = mongoDBHandler.getAllDocuments(
-                    database, subscriptionCollectionName);
-            subscriptions.forEach(
+        List<String> subscriptions = mongoDBHandler.getAllDocuments(
+                database, subscriptionCollectionName);
+        subscriptions.forEach(
                 subscription -> extractConditions(aggregatedObject,
-                    subscription, id));
+                        subscription, id));
     }
 
     /**

--- a/src/main/java/com/ericsson/ei/subscription/SubscriptionHandler.java
+++ b/src/main/java/com/ericsson/ei/subscription/SubscriptionHandler.java
@@ -74,15 +74,11 @@ public class SubscriptionHandler {
      */
     public void checkSubscriptionForObject(final String aggregatedObject,
                                            final String id) {
-        Thread subscriptionThread = new Thread(() -> {
             List<String> subscriptions = mongoDBHandler.getAllDocuments(
                     database, subscriptionCollectionName);
             subscriptions.forEach(
                 subscription -> extractConditions(aggregatedObject,
                     subscription, id));
-        });
-        subscriptionThread.setName("SubscriptionHandler");
-        subscriptionThread.start();
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,6 +76,6 @@ spring.mongodb.embedded.version: 3.4.1
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 
 threads.core.pool.size: 100
-threads.queue.capacity: 1
+threads.queue.capacity: 150
 threads.max.pool.size: 150
 scheduled.threadpool.size: 100

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,7 @@ rabbitmq.waitlist.queue.suffix: waitList
 
 bindingkeys.collection.name: binding_keys
 
-spring.data.mongodb.uri: mongodb://localhost:27017
+spring.data.mongodb.uri: mongodb://localhost:27017/?autoReconnect=true&retryReads=true&retryWrites=true&connectTimeoutMS=400000&socketTimeoutMS=400000&safe=true
 spring.data.mongodb.database: eiffel_intelligence
 
 server.session.timeout: 1200

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,7 +35,7 @@ server.session.timeout: 1200
 sessions.collection.name: sessions
 
 aggregations.collection.name: aggregations
-aggregations.collection.ttl:
+aggregations.collection.ttl: 123
 event.object.map.collection.name: event_object_map
 subscriptions.collection.name: subscriptions
 subscriptions.repeat.handler.collection.name: subscriptions_repeat_handler
@@ -75,7 +75,7 @@ spring.mongodb.embedded.version: 3.4.1
 # starts and activate it manually in tests where we need the Spring's own embedded mongo DB
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 
-threads.core.pool.size: 100
-threads.queue.capacity: 5000
-threads.max.pool.size: 150
-scheduled.threadpool.size: 100
+threads.core.pool.size: 200
+threads.queue.capacity: 1
+threads.max.pool.size: 250
+scheduled.threadpool.size: 200

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,7 @@ rabbitmq.waitlist.queue.suffix: waitList
 
 bindingkeys.collection.name: binding_keys
 
-spring.data.mongodb.uri: mongodb://localhost:27017/?autoReconnect=true&retryReads=true&retryWrites=true&safe=true
+spring.data.mongodb.uri: mongodb://localhost:27017
 spring.data.mongodb.database: eiffel_intelligence
 
 server.session.timeout: 1200

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,7 @@ rabbitmq.waitlist.queue.suffix: waitList
 
 bindingkeys.collection.name: binding_keys
 
-spring.data.mongodb.uri: mongodb://localhost:27017/?autoReconnect=true&retryReads=true&retryWrites=true&connectTimeoutMS=400000&socketTimeoutMS=400000&safe=true
+spring.data.mongodb.uri: mongodb://localhost:27017/?autoReconnect=true&retryReads=true&retryWrites=true&safe=true
 spring.data.mongodb.database: eiffel_intelligence
 
 server.session.timeout: 1200

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,6 +76,6 @@ spring.mongodb.embedded.version: 3.4.1
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 
 threads.core.pool.size: 100
-threads.queue.capacity: 150
+threads.queue.capacity: 5000
 threads.max.pool.size: 150
 scheduled.threadpool.size: 100

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,7 +75,7 @@ spring.mongodb.embedded.version: 3.4.1
 # starts and activate it manually in tests where we need the Spring's own embedded mongo DB
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 
-threads.core.pool.size: 400
-threads.queue.capacity: 1
-threads.max.pool.size: 450
-scheduled.threadpool.size: 400
+threads.core.pool.size: 200
+threads.queue.capacity: 7000
+threads.max.pool.size: 250
+scheduled.threadpool.size: 200

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,7 +75,7 @@ spring.mongodb.embedded.version: 3.4.1
 # starts and activate it manually in tests where we need the Spring's own embedded mongo DB
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 
-threads.core.pool.size: 200
+threads.core.pool.size: 100
 threads.queue.capacity: 1
-threads.max.pool.size: 250
-scheduled.threadpool.size: 200
+threads.max.pool.size: 150
+scheduled.threadpool.size: 100

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,7 +35,7 @@ server.session.timeout: 1200
 sessions.collection.name: sessions
 
 aggregations.collection.name: aggregations
-aggregations.collection.ttl: 123
+aggregations.collection.ttl:
 event.object.map.collection.name: event_object_map
 subscriptions.collection.name: subscriptions
 subscriptions.repeat.handler.collection.name: subscriptions_repeat_handler
@@ -75,7 +75,7 @@ spring.mongodb.embedded.version: 3.4.1
 # starts and activate it manually in tests where we need the Spring's own embedded mongo DB
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 
-threads.core.pool.size: 100
-threads.queue.capacity: 5000
-threads.max.pool.size: 150
-scheduled.threadpool.size: 100
+threads.core.pool.size: 400
+threads.queue.capacity: 1
+threads.max.pool.size: 450
+scheduled.threadpool.size: 400


### PR DESCRIPTION
### Applicable Issues
Today EI consume a lot of CPU and Memory reasources due to EI can consume a lot events that causes spawning a lot of threads that causes high JVM CPU and Memory load.
Since each thread has also has a MongoDB connector, it will cause high load on MongoDB as well.

### Description of the Change
In some deployments it has been reported that EI consumes to much resource(CPU, memory) and this due to that we use unlimited number of threads for matching aggregations with subscriptions jmePaths and in same time a lot of MongoDB queries is made from these threads, which causes extra load on MongoDb.

With this change only one and same thread that consumes the event from MessageBus is used through whole EI.

By doing this, we avoid using too much memory and too much CPU.
If the system that is used can handle more events and aggregations, then increase the threadpool size configuration in application.properties file.

This includes the fix for duplication of AggreagationsTtl fields in Infromation RestApi.
Old and faulty "/information" entrypoint return value:
"objectHandler" : {
"aggregationsCollectionName" : "aggregations",
"databaseName" : "eiffel_intelligence",
"ttl" : 0
"aggregationsTtl" : ""
},
With this PR change, which is how it should be:
"objectHandler" : {
"aggregationsCollectionName" : "aggregations",
"databaseName" : "eiffel_intelligence",
"aggregationsTtl" : ""
},

Fixed MongoDbHandler so MongoDb connection is restored in case of MongoDB connection goes down and comes up again, then connection is automatically restored.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Reduce load on JVM and MongoDb and minimize overload on MongoDb.

### Possible Drawbacks
EI might consume events in a slower pace.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @tobiasake 
