### PR TITLE
Removed the duplication of Ttl fields in /Infromation RestApi

### DIFF
--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
 import com.ericsson.ei.subscription.SubscriptionHandler;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -254,6 +255,7 @@ public class ObjectHandler {
      * @return ttl
      *     Integer value representing time to live for documents
      * */
+    @JsonIgnore
     public int getTtl() {
         int ttl = 0;
         if (ttlValue != null && !ttlValue.isEmpty()) {


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change

This fix for duplication of ttl fields in Information RestApi.
Old and faulty "/information" entrypoint return value:
 "objectHandler": {
    "collectionName": "aggregated_objects",
    "databaseName": "eiffel_intelligence",
    "ttlValue": "",
    "ttl": 0
  },
  
With this PR change, which is how it should be:

"objectHandler": {
    "collectionName": "aggregated_objects",
    "databaseName": "eiffel_intelligence",
    "ttlValue": ""
  },

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: sudharshan bandaru sudharshan.bandaru@ericsson.com
