### PR TITLE
EIB: Jenkibs job not getting triggered after jenkins uplift to 2.222.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.ericsson</groupId>
     <artifactId>eiffel-intelligence</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.ericsson</groupId>
     <artifactId>eiffel-intelligence</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.2-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>

--- a/src/main/java/com/ericsson/ei/notifications/JenkinsCrumb.java
+++ b/src/main/java/com/ericsson/ei/notifications/JenkinsCrumb.java
@@ -95,12 +95,12 @@ public class JenkinsCrumb {
      */
     private URL buildJenkinsCrumbUrl(String url) throws MalformedURLException {
         String baseUrl = urlParser.extractBaseUrl(url);
-        String contextPath = urlParser.extractContextPath(url).split("/")[1];
+        final String contextPath = urlParser.extractContextPath(url).split("/")[1];
         URL jenkinsCrumbUrl;
-        if (contextPath.equals("job")) {
+        if ("job".equals(contextPath)) {
             jenkinsCrumbUrl = new URL(baseUrl + JENKINS_CRUMB_ENDPOINT);
         } else {
-            String jenkinsBaseUrl = String.format("%s/%s", baseUrl, contextPath);
+            final String jenkinsBaseUrl = String.format("%s/%s", baseUrl, contextPath);
             jenkinsCrumbUrl = new URL(jenkinsBaseUrl + JENKINS_CRUMB_ENDPOINT);
         }
         return jenkinsCrumbUrl;

--- a/src/main/java/com/ericsson/ei/notifications/JenkinsCrumb.java
+++ b/src/main/java/com/ericsson/ei/notifications/JenkinsCrumb.java
@@ -95,7 +95,14 @@ public class JenkinsCrumb {
      */
     private URL buildJenkinsCrumbUrl(String url) throws MalformedURLException {
         String baseUrl = urlParser.extractBaseUrl(url);
-        URL jenkinsCrumbUrl = new URL(baseUrl + JENKINS_CRUMB_ENDPOINT);
+        String contextPath = urlParser.extractContextPath(url).split("/")[1];
+        URL jenkinsCrumbUrl;
+        if (contextPath.equals("job")) {
+            jenkinsCrumbUrl = new URL(baseUrl + JENKINS_CRUMB_ENDPOINT);
+        } else {
+            String jenkinsBaseUrl = String.format("%s/%s", baseUrl, contextPath);
+            jenkinsCrumbUrl = new URL(jenkinsBaseUrl + JENKINS_CRUMB_ENDPOINT);
+        }
         return jenkinsCrumbUrl;
     }
 }

--- a/src/main/java/com/ericsson/ei/notifications/UrlParser.java
+++ b/src/main/java/com/ericsson/ei/notifications/UrlParser.java
@@ -104,7 +104,7 @@ public class UrlParser {
      * @throws MalformedURLException
      * @throws URISyntaxException
      */
-    private String extractContextPath(String url) throws MalformedURLException {
+    public String extractContextPath(String url) throws MalformedURLException {
         URL absoluteUrl = new URL(url);
         String contextPath = absoluteUrl.getPath();
         return contextPath;

--- a/src/test/java/com/ericsson/ei/notifications/JenkinsCrumbTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/JenkinsCrumbTest.java
@@ -42,7 +42,8 @@ public class JenkinsCrumbTest {
 
     private static final String URL = "http://www.somehot.com/some-endpoint/";
     private static final String BASE_URL = "http://www.somehot.com";
-    private static final String JENKINS_CRUMB_URL = "http://www.somehot.com/crumbIssuer/api/json";
+    private static final String CONTEXT_PATH = "/some-endpoint";
+    private static final String JENKINS_CRUMB_URL = "http://www.somehot.com/some-endpoint/crumbIssuer/api/json";
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
 
@@ -65,6 +66,7 @@ public class JenkinsCrumbTest {
     public void beforeTests() throws IOException {
         encoding = Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes());
         when(urlParser.extractBaseUrl(URL)).thenReturn(BASE_URL);
+        when(urlParser.extractContextPath(URL)).thenReturn(CONTEXT_PATH);
 
         headers.add("Authorization", "Basic " + encoding);
         headers.setContentType(MediaType.APPLICATION_JSON);


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
With jenkins uplift to 2.222.3, we have CSRF protection which needs crumbs to make rest post calls to jenkins.
The crumb issuer end point is not working which will be hitted when BASIC_AUTH_CSRF_PROTECTION is the AUTH_TYPE
for the subscrptions to trigger the jenkins jobs. Due to this the jenkins obs are not getting triggered. 
Made the code change that triggers the jenkins jobs for the subscrptions for AUTH_TYPE "BASIC_AUTH_CSRF_PROTECTION"

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: K.Suryakumari suryakumari.kolli@ericsson.com
