### PR TITLE
events are not processing from queue

### DIFF
--- a/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
@@ -27,7 +27,6 @@ import org.springframework.util.SocketUtils;
 
 import com.ericsson.ei.exception.AuthenticationException;
 import com.ericsson.ei.exception.MongoDBConnectionException;
-import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.notifications.InformSubscriber;
 import com.ericsson.ei.utils.FunctionalTestBase;

--- a/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.SocketUtils;
 
 import com.ericsson.ei.exception.AuthenticationException;
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.notifications.InformSubscriber;
 import com.ericsson.ei.utils.FunctionalTestBase;
@@ -120,7 +121,7 @@ public class TestTTLSteps extends FunctionalTestBase {
     }
 
     @When("^I want to inform subscriber$")
-    public void inform_subscriber() throws IOException, AuthenticationException {
+    public void inform_subscriber() throws IOException, AuthenticationException, SubscriptionValidationException {
         JsonNode aggregatedObject = eventManager.getJSONFromFile(AGGREGATED_OBJECT_FILE_PATH);
         informSubscriber.informSubscriber(aggregatedObject.toString(), subscriptionObject);
     }

--- a/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.SocketUtils;
 
 import com.ericsson.ei.exception.AuthenticationException;
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.notifications.InformSubscriber;
@@ -121,7 +122,7 @@ public class TestTTLSteps extends FunctionalTestBase {
     }
 
     @When("^I want to inform subscriber$")
-    public void inform_subscriber() throws IOException, AuthenticationException, SubscriptionValidationException {
+    public void inform_subscriber() throws IOException, AuthenticationException, MongoDBConnectionException {
         JsonNode aggregatedObject = eventManager.getJSONFromFile(AGGREGATED_OBJECT_FILE_PATH);
         informSubscriber.informSubscriber(aggregatedObject.toString(), subscriptionObject);
     }

--- a/src/main/java/com/ericsson/ei/controller/RuleControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleControllerImpl.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import com.ericsson.ei.controller.model.RuleCheckBody;
 import com.ericsson.ei.controller.model.RulesCheckBody;
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesHandler;
@@ -140,7 +141,7 @@ public class RuleControllerImpl implements RuleController{
                     String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
                     return new ResponseEntity<>(errorJsonAsString, HttpStatus.BAD_REQUEST);
                 }
-            } catch (JSONException | IOException | SubscriptionValidationException e) {
+            } catch (JSONException | IOException | MongoDBConnectionException e) {
                 String errorMessage = "Internal Server Error: Failed to generate aggregated object.";
                 LOGGER.error(errorMessage, e);
                 String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);

--- a/src/main/java/com/ericsson/ei/controller/RuleControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleControllerImpl.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import com.ericsson.ei.controller.model.RuleCheckBody;
 import com.ericsson.ei.controller.model.RulesCheckBody;
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesHandler;
 import com.ericsson.ei.services.IRuleCheckService;
@@ -139,7 +140,7 @@ public class RuleControllerImpl implements RuleController{
                     String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);
                     return new ResponseEntity<>(errorJsonAsString, HttpStatus.BAD_REQUEST);
                 }
-            } catch (JSONException | IOException e) {
+            } catch (JSONException | IOException | SubscriptionValidationException e) {
                 String errorMessage = "Internal Server Error: Failed to generate aggregated object.";
                 LOGGER.error(errorMessage, e);
                 String errorJsonAsString = ResponseMessage.createJsonMessage(errorMessage);

--- a/src/main/java/com/ericsson/ei/controller/RuleControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleControllerImpl.java
@@ -34,7 +34,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import com.ericsson.ei.controller.model.RuleCheckBody;
 import com.ericsson.ei.controller.model.RulesCheckBody;
 import com.ericsson.ei.exception.MongoDBConnectionException;
-import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesHandler;
 import com.ericsson.ei.services.IRuleCheckService;

--- a/src/main/java/com/ericsson/ei/exception/MongoDBConnectionException.java
+++ b/src/main/java/com/ericsson/ei/exception/MongoDBConnectionException.java
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 Ericsson AB.
+For a full list of individual contributors, please see the commit history.
+
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.ericsson.ei.exception;
+
+public class MongoDBConnectionException extends Exception {
+
+	private static final long serialVersionUID = 2L;
+
+	public MongoDBConnectionException() {
+		super();
+	}
+
+	public MongoDBConnectionException(String message) {
+		super(message);
+	}
+
+	public MongoDBConnectionException(String message, Throwable e) {
+		super(message, e);
+	}
+
+}

--- a/src/main/java/com/ericsson/ei/handlers/DownstreamIdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/DownstreamIdRulesHandler.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
@@ -50,7 +51,7 @@ public class DownstreamIdRulesHandler {
         this.jmesPathInterface = jmesPathInterface;
     }
 
-    public void runIdRules(RulesObject rulesObject, String event) throws SubscriptionValidationException {
+    public void runIdRules(RulesObject rulesObject, String event) throws MongoDBConnectionException {
         if (rulesObject != null && event != null) {
             JsonNode idsJsonObj = getIds(rulesObject, event);
             List<String> objects;

--- a/src/main/java/com/ericsson/ei/handlers/DownstreamIdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/DownstreamIdRulesHandler.java
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.ericsson.ei.exception.MongoDBConnectionException;
-import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
 import com.ericsson.ei.waitlist.WaitListStorageHandler;

--- a/src/main/java/com/ericsson/ei/handlers/DownstreamIdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/DownstreamIdRulesHandler.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
 import com.ericsson.ei.waitlist.WaitListStorageHandler;
@@ -49,7 +50,7 @@ public class DownstreamIdRulesHandler {
         this.jmesPathInterface = jmesPathInterface;
     }
 
-    public void runIdRules(RulesObject rulesObject, String event) {
+    public void runIdRules(RulesObject rulesObject, String event) throws SubscriptionValidationException {
         if (rulesObject != null && event != null) {
             JsonNode idsJsonObj = getIds(rulesObject, event);
             List<String> objects;

--- a/src/main/java/com/ericsson/ei/handlers/EventHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/EventHandler.java
@@ -16,16 +16,24 @@
 */
 package com.ericsson.ei.handlers;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.core.Message;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.config.SpringAsyncConfig;
+import com.ericsson.ei.encryption.Encryptor;
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.rules.RulesHandler;
 import com.ericsson.ei.rules.RulesObject;
+import com.ericsson.ei.utils.SpringContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.Channel;
@@ -46,14 +54,17 @@ public class EventHandler {
 
     @Autowired
     Environment environment;
+    
 
     public RulesHandler getRulesHandler() {
         return rulesHandler;
     }
 
-    public void eventReceived(final String event) {
+    public void eventReceived(final String event) throws SubscriptionValidationException {
+        
         final RulesObject eventRules = rulesHandler.getRulesForEvent(event);
         idRulesHandler.runIdRules(eventRules, event);
+        
     }
 
     @Async("eventHandlerExecutor")
@@ -63,12 +74,17 @@ public class EventHandler {
         final JsonNode node = objectMapper.readTree(messageBody);
         final String id = node.get("meta").get("id").toString();
         LOGGER.debug("Thread id {} spawned for EventHandler", Thread.currentThread().getId());
-        LOGGER.debug("Event {} received", id);
-
-        eventReceived(messageBody);
-        final long deliveryTag = message.getMessageProperties().getDeliveryTag();
-        channel.basicAck(deliveryTag, false);
-
-        LOGGER.debug("Event {} processed", id);
-    }
+        try {
+            eventReceived(messageBody);
+            final long deliveryTag = message.getMessageProperties().getDeliveryTag();
+            channel.basicAck(deliveryTag, false);
+            LOGGER.info("Event {} processed", id);
+        }catch(SubscriptionValidationException sbe) {
+            LOGGER.info("SubscriptionValidationException handled in Catch block ", id);
+            final long deliveryTag = message.getMessageProperties().getDeliveryTag();
+            channel.basicNack(deliveryTag, false, true);
+            LOGGER.info("SubscriptionValidationException handled in Catch block  done", id);
+        }
+    }  
 }
+

--- a/src/main/java/com/ericsson/ei/handlers/ExtractionHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ExtractionHandler.java
@@ -93,7 +93,7 @@ public class ExtractionHandler {
                 upStreamEventsHandler.runHistoryExtractionRulesOnAllUpstreamEvents(mergeId);
             }
         } catch (Exception e) {
-            LOGGER.error("Failed to run extraction for event {} , stacktrace1 hello {} ", event, ExceptionUtils.getStackTrace(e));
+        	LOGGER.error("Failed to run extraction for event {} , stacktrace {}", event, ExceptionUtils.getStackTrace(e));
             if (e.getMessage().equalsIgnoreCase("MongoDB Connection down")) {
                 throw new MongoDBConnectionException("MongoDB Connection down");
             }

--- a/src/main/java/com/ericsson/ei/handlers/ExtractionHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ExtractionHandler.java
@@ -61,17 +61,20 @@ public class ExtractionHandler {
         this.objectHandler = objectHandler;
     }
 
-    public void runExtraction(RulesObject rulesObject, String id, String event, String aggregatedDbObject) {
+    public void runExtraction(RulesObject rulesObject, String id, String event, String aggregatedDbObject) throws MongoDBConnectionException {
         try {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode aggregatedJsonObject = mapper.readTree(aggregatedDbObject);
             runExtraction(rulesObject, id, event, aggregatedJsonObject);
         } catch (Exception e) {
-            LOGGER.info("Failed with extraction.", e);
+            LOGGER.error("Failed with extraction.", e);
+            if (e.getMessage().equalsIgnoreCase("MongoDB Connection down")) {
+                throw new MongoDBConnectionException("MongoDB Connection down");
+            }
         }
     }
 
-    public void runExtraction(RulesObject rulesObject, String mergeId, String event, JsonNode aggregatedDbObject) throws MongoDBConnectionException {
+    public void runExtraction(RulesObject rulesObject, String mergeId, String event, JsonNode aggregatedDbObject) throws MongoDBConnectionException  {
         try {
             JsonNode extractedContent = extractContent(rulesObject, event);
 
@@ -90,7 +93,10 @@ public class ExtractionHandler {
                 upStreamEventsHandler.runHistoryExtractionRulesOnAllUpstreamEvents(mergeId);
             }
         } catch (Exception e) {
-            LOGGER.error("Failed to run extraction for event {} , stacktrace {}", event, ExceptionUtils.getStackTrace(e));
+            LOGGER.error("Failed to run extraction for event {} , stacktrace1 hello {} ", event, ExceptionUtils.getStackTrace(e));
+            if (e.getMessage().equalsIgnoreCase("MongoDB Connection down")) {
+                throw new MongoDBConnectionException("MongoDB Connection down");
+            }
         }
     }
 

--- a/src/main/java/com/ericsson/ei/handlers/ExtractionHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ExtractionHandler.java
@@ -93,7 +93,7 @@ public class ExtractionHandler {
                 upStreamEventsHandler.runHistoryExtractionRulesOnAllUpstreamEvents(mergeId);
             }
         } catch (Exception e) {
-        	LOGGER.error("Failed to run extraction for event {} , stacktrace {}", event, ExceptionUtils.getStackTrace(e));
+            LOGGER.error("Failed to run extraction for event {} , stacktrace {}", event, ExceptionUtils.getStackTrace(e));
             if (e.getMessage().equalsIgnoreCase("MongoDB Connection down")) {
                 throw new MongoDBConnectionException("MongoDB Connection down");
             }

--- a/src/main/java/com/ericsson/ei/handlers/ExtractionHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ExtractionHandler.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.jsonmerge.MergeHandler;
 import com.ericsson.ei.rules.RulesObject;
@@ -70,7 +71,7 @@ public class ExtractionHandler {
         }
     }
 
-    public void runExtraction(RulesObject rulesObject, String mergeId, String event, JsonNode aggregatedDbObject) {
+    public void runExtraction(RulesObject rulesObject, String mergeId, String event, JsonNode aggregatedDbObject) throws MongoDBConnectionException {
         try {
             JsonNode extractedContent = extractContent(rulesObject, event);
 

--- a/src/main/java/com/ericsson/ei/handlers/IdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/IdRulesHandler.java
@@ -16,17 +16,18 @@
 */
 package com.ericsson.ei.handlers;
 
-import com.ericsson.ei.exception.SubscriptionValidationException;
-import com.ericsson.ei.jmespath.JmesPathInterface;
-import com.ericsson.ei.rules.RulesObject;
-import com.ericsson.ei.waitlist.WaitListStorageHandler;
-import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import com.ericsson.ei.exception.MongoDBConnectionException;
+import com.ericsson.ei.jmespath.JmesPathInterface;
+import com.ericsson.ei.rules.RulesObject;
+import com.ericsson.ei.waitlist.WaitListStorageHandler;
+import com.fasterxml.jackson.databind.JsonNode;
 
 
 @Component
@@ -50,7 +51,7 @@ public class IdRulesHandler {
         this.jmesPathInterface = jmesPathInterface;
     }
 
-    public void runIdRules(RulesObject rulesObject, String event) throws SubscriptionValidationException {
+    public void runIdRules(RulesObject rulesObject, String event) throws MongoDBConnectionException {
         if (rulesObject != null && event != null) {
             JsonNode idsJsonObj = getIds(rulesObject, event);
             if (idsJsonObj != null && idsJsonObj.isArray()) {

--- a/src/main/java/com/ericsson/ei/handlers/IdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/IdRulesHandler.java
@@ -16,18 +16,17 @@
 */
 package com.ericsson.ei.handlers;
 
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
 import com.ericsson.ei.waitlist.WaitListStorageHandler;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 
 @Component

--- a/src/main/java/com/ericsson/ei/handlers/IdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/IdRulesHandler.java
@@ -16,6 +16,7 @@
 */
 package com.ericsson.ei.handlers;
 
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
 import com.ericsson.ei.waitlist.WaitListStorageHandler;
@@ -49,7 +50,7 @@ public class IdRulesHandler {
         this.jmesPathInterface = jmesPathInterface;
     }
 
-    public void runIdRules(RulesObject rulesObject, String event) {
+    public void runIdRules(RulesObject rulesObject, String event) throws SubscriptionValidationException {
         if (rulesObject != null && event != null) {
             JsonNode idsJsonObj = getIds(rulesObject, event);
             if (idsJsonObj != null && idsJsonObj.isArray()) {

--- a/src/main/java/com/ericsson/ei/handlers/IdRulesHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/IdRulesHandler.java
@@ -58,8 +58,9 @@ public class IdRulesHandler {
                 for (final JsonNode idJsonObj : idsJsonObj) {
                     final String id = idJsonObj.textValue();
                     final List<String> aggregatedObjects = matchIdRulesHandler.fetchObjectsById(rulesObject, id);
-                    aggregatedObjects.forEach(
-                        aggregatedObject -> extractionHandler.runExtraction(rulesObject, id, event, aggregatedObject));
+                    for(String aggregatedObject : aggregatedObjects) {
+                        extractionHandler.runExtraction(rulesObject, id, event, aggregatedObject);
+                    }
                     if (aggregatedObjects.size() == 0) {
                         if (rulesObject.isStartEventRules()) {
                             extractionHandler.runExtraction(rulesObject, id, event, (JsonNode) null);

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -262,8 +262,8 @@ public class MongoDBHandler {
                 final Document dbObjectCondition = Document.parse(condition);
                 DeleteResult deleteMany = collection.deleteMany(dbObjectCondition);
                 if (deleteMany.getDeletedCount() > 0) {
-					LOGGER.debug("database: {} and collection: {} deleted No.of records {}", dataBaseName,
-							collectionName, deleteMany.getDeletedCount());
+                	LOGGER.debug("database: {} and collection: {} deleted No.of records {}", dataBaseName,
+                			collectionName, deleteMany.getDeletedCount());
                     return true;
                 } else {
                     LOGGER.debug("database {} and collection: {} No documents found to delete.", dataBaseName,

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -262,12 +262,10 @@ public class MongoDBHandler {
                 final Document dbObjectCondition = Document.parse(condition);
                 DeleteResult deleteMany = collection.deleteMany(dbObjectCondition);
                 if (deleteMany.getDeletedCount() > 0) {
-                	LOGGER.debug("database: {} and collection: {} deleted No.of records {}", dataBaseName,
-                			collectionName, deleteMany.getDeletedCount());
+                    LOGGER.debug("database: {} and collection: {} deleted No.of records {}", dataBaseName, collectionName, deleteMany.getDeletedCount());
                     return true;
                 } else {
-                    LOGGER.debug("database {} and collection: {} No documents found to delete.", dataBaseName,
-                            collectionName);
+                    LOGGER.debug("database {} and collection: {} No documents found to delete.", dataBaseName, collectionName);
                     return false;
                 }
             }

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -262,8 +262,8 @@ public class MongoDBHandler {
                 final Document dbObjectCondition = Document.parse(condition);
                 DeleteResult deleteMany = collection.deleteMany(dbObjectCondition);
                 if (deleteMany.getDeletedCount() > 0) {
-                    LOGGER.debug("database: {} and collection: {} deleted No.of records {}", dataBaseName,
-                            collectionName, deleteMany.getDeletedCount());
+					LOGGER.debug("database: {} and collection: {} deleted No.of records {}", dataBaseName,
+							collectionName, deleteMany.getDeletedCount());
                     return true;
                 } else {
                     LOGGER.debug("database {} and collection: {} No documents found to delete.", dataBaseName,

--- a/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/MongoDBHandler.java
@@ -30,7 +30,6 @@ import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.stereotype.Component;
 
 import com.ericsson.ei.exception.MongoDBConnectionException;
-import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.mongodb.BasicDBObject;
 import com.mongodb.Block;
@@ -90,15 +89,13 @@ public class MongoDBHandler {
             mongoClient = new MongoClient(mongoProperties.getHost(), mongoProperties.getPort());
         }
     }
-    
 
     /**
      * This method used for the insert the document into collection
      *
      * @param dataBaseName
      * @param collectionName
-     * @param input
-     *            json String
+     * @param input          json String
      * @return
      */
     public void insertDocument(String dataBaseName, String collectionName, String input) throws MongoWriteException {
@@ -108,8 +105,7 @@ public class MongoDBHandler {
             if (collection != null) {
                 final Document dbObjectInput = Document.parse(input);
                 collection.insertOne(dbObjectInput);
-                LOGGER.debug("Object: {}\n was inserted successfully in collection: {} and database {}.", input,
-                        collectionName, dataBaseName);
+                LOGGER.debug("Object: {}\n was inserted successfully in collection: {} and database {}.", input, collectionName, dataBaseName);
             }
         } catch (Exception e) {
             LOGGER.error("Failed to insert Object: {} \n in collection: {} and database {}. \n {}", input,
@@ -135,8 +131,7 @@ public class MongoDBHandler {
                 if (result.size() != 0) {
                     // This will pass about 10 times/second and most of the times DB will be empty,
                     // this is normal, no need to log
-                    LOGGER.debug("getAllDocuments() :: database: {} and collection: {} fetched No of : {}",
-                            dataBaseName, collectionName, result.size());
+                    LOGGER.debug("getAllDocuments() :: database: {} and collection: {} fetched No of : {}", dataBaseName, collectionName, result.size());
                 }
             }
         } catch (Exception e) {
@@ -150,15 +145,13 @@ public class MongoDBHandler {
      *
      * @param dataBaseName
      * @param collectionName
-     * @param condition
-     *            a condition to find a requested object in the database
+     * @param condition      a condition to find a requested object in the database
      * @return
      */
     public ArrayList<String> find(String dataBaseName, String collectionName, String condition) {
         ArrayList<String> result = new ArrayList<>();
 
-        LOGGER.debug("Find and retrieve data from database.\nDatabase: {}\nCollection: {}\nCondition/Query: {}",
-                dataBaseName, collectionName, condition);
+        LOGGER.debug("Find and retrieve data from database.\nDatabase: {}\nCollection: {}\nCondition/Query: {}", dataBaseName, collectionName, condition);
 
         try {
             MongoCollection<Document> collection = getMongoCollection(dataBaseName, collectionName);
@@ -167,11 +160,9 @@ public class MongoDBHandler {
                     result.add(JSON.serialize(document));
                 });
                 if (result.size() != 0) {
-                    LOGGER.debug("find() :: database: {} and collection: {} fetched No of : {}", dataBaseName,
-                            collectionName, result.size());
+                    LOGGER.debug("find() :: database: {} and collection: {} fetched No of : {}", dataBaseName, collectionName, result.size());
                 } else {
-                    LOGGER.debug("find() :: database: {} and collection: {} documents are not found", dataBaseName,
-                            collectionName);
+                    LOGGER.debug("find() :: database: {} and collection: {} documents are not found", dataBaseName, collectionName);
                 }
             } else {
                 LOGGER.debug("Collection {} is empty in database {}", collectionName, dataBaseName);
@@ -189,10 +180,8 @@ public class MongoDBHandler {
      *
      * @param dataBaseName
      * @param collectionName
-     * @param input
-     *            is a json string
-     * @param updateInput
-     *            is updated document without lock
+     * @param input          is a json string
+     * @param updateInput    is updated document without lock
      * @return
      */
     public boolean updateDocument(String dataBaseName, String collectionName, String input, String updateInput) {
@@ -202,8 +191,7 @@ public class MongoDBHandler {
                 final Document dbObjectInput = Document.parse(input);
                 final Document dbObjectUpdateInput = Document.parse(updateInput);
                 UpdateResult updateMany = collection.replaceOne(dbObjectInput, dbObjectUpdateInput);
-                LOGGER.debug("updateDocument() :: database: {} and collection: {} is document Updated : {}",
-                        dataBaseName, collectionName, updateMany.wasAcknowledged());
+                LOGGER.debug("updateDocument() :: database: {} and collection: {} is document Updated : {}", dataBaseName, collectionName, updateMany.wasAcknowledged());
                 return updateMany.wasAcknowledged();
             }
         } catch (Exception e) {
@@ -220,10 +208,8 @@ public class MongoDBHandler {
      *
      * @param dataBaseName
      * @param collectionName
-     * @param input
-     *            is a condition for update documents
-     * @param updateInput
-     *            is updated document without lock
+     * @param input          is a condition for update documents
+     * @param updateInput    is updated document without lock
      * @return
      */
     public Document findAndModify(String dataBaseName, String collectionName, String input, String updateInput) {
@@ -234,8 +220,7 @@ public class MongoDBHandler {
                 final Document dbObjectUpdateInput = Document.parse(updateInput);
                 Document result = collection.findOneAndUpdate(dbObjectInput, dbObjectUpdateInput);
                 if (result != null) {
-                    LOGGER.debug("updateDocument() :: database: {} and collection: {} updated successfully",
-                            dataBaseName, collectionName);
+                    LOGGER.debug("updateDocument() :: database: {} and collection: {} updated successfully", dataBaseName, collectionName);
                     return result;
                 }
             }
@@ -251,8 +236,7 @@ public class MongoDBHandler {
      *
      * @param dataBaseName
      * @param collectionName
-     * @param condition
-     *            string json
+     * @param condition      string json
      * @return
      */
     public boolean dropDocument(String dataBaseName, String collectionName, String condition) {
@@ -280,12 +264,9 @@ public class MongoDBHandler {
      *
      * @param dataBaseName
      * @param collectionName
-     * @param fieldName
-     *            for index creation field
-     * @param ttlValue
-     *            seconds
-     * @throws SubscriptionValidationException
-     * @throws MongoDBConnectionException 
+     * @param fieldName      for index creation field
+     * @param ttlValue       seconds
+     * @throws MongoDBConnectionException
      */
 	public void createTTLIndex(String dataBaseName, String collectionName, String fieldName, int ttlValue)
 			throws MongoDBConnectionException {
@@ -296,45 +277,41 @@ public class MongoDBHandler {
 		} catch (Exception e) {
 			throw new MongoDBConnectionException("MongoDB Connection down");
 		}
-
 	}
 
     private MongoCollection<Document> getMongoCollection(String dataBaseName, String collectionName) {
-       
-        if(mongoClient == null) {
+        if (mongoClient == null)
             return null;
-        }
         MongoDatabase db;
         List<String> collectionList;
         try {
             db = mongoClient.getDatabase(dataBaseName);
             collectionList = db.listCollectionNames().into(new ArrayList<String>());
-        } catch (MongoCommandException e) {
-            LOGGER.error("MongoCommandException, Something went wrong with MongoDb connection. Error: "
-                    + e.getErrorMessage() + "\nStacktrace\n" + e);
-            closeMongoDbConecction();
-            return null;
-        } catch (MongoInterruptedException e) {
-            LOGGER.error(" MongoInterruptedException, MongoDB shutdown or interrupted. Error: " + e.getMessage()
-                    + "\nStacktrace\n" + e);
-            closeMongoDbConecction();
-            return null;
-        } catch (MongoSocketReadException e) {
-            LOGGER.error("MongoSocketReadException, MongoDB shutdown or interrupted. Error: " + e.getMessage()
-                    + "\nStacktrace\n" + e);
+        }
+        catch (MongoCommandException e) {
+            LOGGER.error("MongoCommandException, Something went wrong with MongoDb connection. Error: " + e.getErrorMessage() + "\nStacktrace\n" + e);
             closeMongoDbConecction();
             return null;
         }
-
+        catch (MongoInterruptedException e) {
+            LOGGER.error(" MongoInterruptedException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStacktrace\n" + e);
+            closeMongoDbConecction();
+            return null;
+        }
+        catch (MongoSocketReadException e) {
+            LOGGER.error("MongoSocketReadException, MongoDB shutdown or interrupted. Error: " + e.getMessage() + "\nStacktrace\n" + e);
+            closeMongoDbConecction();
+            return null;
+        }
+        
         catch (IllegalStateException e) {
             LOGGER.error("IllegalStateException, MongoDB state not good. Error: " + e.getMessage());
             closeMongoDbConecction();
             return null;
         }
-
+        
         if (!collectionList.contains(collectionName)) {
-            LOGGER.debug("The requested database({}) / collection({}) not available in mongodb, Creating ........",
-                    dataBaseName, collectionName);
+            LOGGER.debug("The requested database({}) / collection({}) not available in mongodb, Creating ........", dataBaseName, collectionName);
             try {
                 db.createCollection(collectionName);
             } catch (MongoCommandException e) {
@@ -357,14 +334,12 @@ public class MongoDBHandler {
         }
         mongoClient = null;
     }
-
+    
     /**
      * This method is used to drop a collection.
      *
-     * @param dataBaseName
-     *            to know which database to drop a collection from
-     * @param collectionName
-     *            to know which collection to drop
+     * @param dataBaseName   to know which database to drop a collection from
+     * @param collectionName to know which collection to drop
      */
     public void dropCollection(String dataBaseName, String collectionName) {
         MongoDatabase db = mongoClient.getDatabase(dataBaseName);
@@ -375,21 +350,18 @@ public class MongoDBHandler {
     /**
      * This method is used to drop a database. For example after testing.
      *
-     * @param dataBaseName
-     *            to know which database to remove
+     * @param dataBaseName to know which database to remove
      */
     public void dropDatabase(String databaseName) {
         MongoDatabase db = mongoClient.getDatabase(databaseName);
         db.drop();
     }
-
+    
     /**
      * Check if the document exists
-     * 
      * @param databaseName
      * @param collectionName
-     * @param condition
-     *            a condition to find a requested object in the database
+     * @param condition      a condition to find a requested object in the database
      * @return
      */
     public boolean checkDocumentExists(String databaseName, String collectionName, String condition) {
@@ -410,28 +382,24 @@ public class MongoDBHandler {
         }
         return true;
     }
-
+    
+    
     /**
-     * Update the existing documents with unique objects list Used only in
-     * EventToObjectMapHandler.java
-     * 
+     * Update the existing documents with unique objects list
+     * Used only in EventToObjectMapHandler.java
      * @param dataBaseName
      * @param collectionName
-     * @param condition
-     *            a condition to find a requested object in the database
-     * @param eventId
-     *            eventId to update in the mapper collection
-     * @return
+     * @param condition      a condition to find a requested object in the database
+     * @param eventId eventId to update in the mapper collection
+     * @return 
      */
-    public boolean updateDocumentAddToSet(String dataBaseName, String collectionName, String condition,
-            String eventId) {
+    public boolean updateDocumentAddToSet(String dataBaseName, String collectionName, String condition, String eventId) {
         try {
             MongoCollection<Document> collection = getMongoCollection(dataBaseName, collectionName);
             if (collection != null) {
                 final Document dbObjectInput = Document.parse(condition);
                 UpdateResult updateMany = collection.updateOne(dbObjectInput, Updates.addToSet("objects", eventId));
-                LOGGER.debug("updateDocument() :: database: {} and collection: {} is document Updated : {}",
-                        dataBaseName, collectionName, updateMany.wasAcknowledged());
+                LOGGER.debug("updateDocument() :: database: {} and collection: {} is document Updated : {}", dataBaseName, collectionName, updateMany.wasAcknowledged());
                 return updateMany.wasAcknowledged();
             }
         } catch (Exception e) {
@@ -449,7 +417,6 @@ public class MongoDBHandler {
 	 * @param dataBaseName
 	 * @return true if the connection is up otherwise return false
 	 */
-
 	public boolean checkMongoDbStatus(String dataBaseName) {
 		MongoDatabase db;
 		List<String> collectionList;

--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.ericsson.ei.exception.MongoDBConnectionException;
-import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
 import com.ericsson.ei.subscription.SubscriptionHandler;

--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
@@ -90,7 +91,7 @@ public class ObjectHandler {
      *      String id is stored together with aggregated object in database
      * @throws SubscriptionValidationException 
      * */
-    public void insertObject(String aggregatedObject, RulesObject rulesObject, String event, String id) throws SubscriptionValidationException {
+    public void insertObject(String aggregatedObject, RulesObject rulesObject, String event, String id) throws MongoDBConnectionException {
         if (id == null) {
             String idRules = rulesObject.getIdRule();
             JsonNode idNode = jmespathInterface.runRuleOnEvent(idRules, event);
@@ -107,7 +108,7 @@ public class ObjectHandler {
         postInsertActions(aggregatedObject, rulesObject, event, id);
     }
 
-    public void insertObject(JsonNode aggregatedObject, RulesObject rulesObject, String event, String id) throws SubscriptionValidationException {
+    public void insertObject(JsonNode aggregatedObject, RulesObject rulesObject, String event, String id) throws MongoDBConnectionException {
         insertObject(aggregatedObject.toString(), rulesObject, event, id);
     }
 

--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
 import com.ericsson.ei.subscription.SubscriptionHandler;
@@ -87,8 +88,9 @@ public class ObjectHandler {
      *      String representation of event, used to fetch id if not specified
      * @param id
      *      String id is stored together with aggregated object in database
+     * @throws SubscriptionValidationException 
      * */
-    public void insertObject(String aggregatedObject, RulesObject rulesObject, String event, String id) {
+    public void insertObject(String aggregatedObject, RulesObject rulesObject, String event, String id) throws SubscriptionValidationException {
         if (id == null) {
             String idRules = rulesObject.getIdRule();
             JsonNode idNode = jmespathInterface.runRuleOnEvent(idRules, event);
@@ -105,7 +107,7 @@ public class ObjectHandler {
         postInsertActions(aggregatedObject, rulesObject, event, id);
     }
 
-    public void insertObject(JsonNode aggregatedObject, RulesObject rulesObject, String event, String id) {
+    public void insertObject(JsonNode aggregatedObject, RulesObject rulesObject, String event, String id) throws SubscriptionValidationException {
         insertObject(aggregatedObject.toString(), rulesObject, event, id);
     }
 

--- a/src/main/java/com/ericsson/ei/jsonmerge/MergeHandler.java
+++ b/src/main/java/com/ericsson/ei/jsonmerge/MergeHandler.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.ObjectHandler;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
@@ -223,11 +224,11 @@ public class MergeHandler {
         return document;
     }
 
-    public void addNewObject(String event, String newObject, RulesObject rulesObject) {
+    public void addNewObject(String event, String newObject, RulesObject rulesObject) throws SubscriptionValidationException {
         objectHandler.insertObject(newObject, rulesObject, event, null);
     }
 
-    public void addNewObject(String event, JsonNode newObject, RulesObject rulesObject) {
+    public void addNewObject(String event, JsonNode newObject, RulesObject rulesObject) throws SubscriptionValidationException {
         objectHandler.insertObject(newObject, rulesObject, event, null);
     }
 }

--- a/src/main/java/com/ericsson/ei/jsonmerge/MergeHandler.java
+++ b/src/main/java/com/ericsson/ei/jsonmerge/MergeHandler.java
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.ericsson.ei.exception.SubscriptionValidationException;
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.handlers.ObjectHandler;
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.rules.RulesObject;
@@ -224,11 +224,11 @@ public class MergeHandler {
         return document;
     }
 
-    public void addNewObject(String event, String newObject, RulesObject rulesObject) throws SubscriptionValidationException {
+    public void addNewObject(String event, String newObject, RulesObject rulesObject) throws MongoDBConnectionException {
         objectHandler.insertObject(newObject, rulesObject, event, null);
     }
 
-    public void addNewObject(String event, JsonNode newObject, RulesObject rulesObject) throws SubscriptionValidationException {
+    public void addNewObject(String event, JsonNode newObject, RulesObject rulesObject) throws MongoDBConnectionException {
         objectHandler.insertObject(newObject, rulesObject, event, null);
     }
 }

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -31,6 +31,7 @@ import org.springframework.util.MultiValueMap;
 
 import com.ericsson.ei.exception.AuthenticationException;
 import com.ericsson.ei.exception.NotificationFailureException;
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.DateUtils;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.jmespath.JmesPathInterface;
@@ -95,7 +96,7 @@ public class InformSubscriber {
      * @throws AuthenticationException
      */
     public void informSubscriber(String aggregatedObject, JsonNode subscriptionJson)
-            throws AuthenticationException {
+            throws AuthenticationException, SubscriptionValidationException {
         SubscriptionField subscriptionField = new SubscriptionField(subscriptionJson);
         String notificationType = subscriptionField.get("notificationType");
         String notificationMeta = subscriptionField.get("notificationMeta");

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -30,8 +30,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import com.ericsson.ei.exception.AuthenticationException;
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.exception.NotificationFailureException;
-import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.DateUtils;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.jmespath.JmesPathInterface;
@@ -96,7 +96,7 @@ public class InformSubscriber {
      * @throws AuthenticationException
      */
     public void informSubscriber(String aggregatedObject, JsonNode subscriptionJson)
-            throws AuthenticationException, SubscriptionValidationException {
+            throws AuthenticationException, MongoDBConnectionException {
         SubscriptionField subscriptionField = new SubscriptionField(subscriptionJson);
         String notificationType = subscriptionField.get("notificationType");
         String notificationMeta = subscriptionField.get("notificationMeta");

--- a/src/main/java/com/ericsson/ei/services/IRuleCheckService.java
+++ b/src/main/java/com/ericsson/ei/services/IRuleCheckService.java
@@ -25,7 +25,7 @@ public interface IRuleCheckService {
      * @throws JSONException
      * @throws JsonProcessingException
      * @throws IOException
-     * @throws SubscriptionValidationException 
+     * @throws MongoDBConnectionException 
      */
     String prepareAggregatedObject(JSONArray listRulesJson, JSONArray listEventsJson)
             throws JSONException, JsonProcessingException, IOException, MongoDBConnectionException;

--- a/src/main/java/com/ericsson/ei/services/IRuleCheckService.java
+++ b/src/main/java/com/ericsson/ei/services/IRuleCheckService.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import org.json.JSONArray;
 import org.json.JSONException;
 
-import com.ericsson.ei.exception.SubscriptionValidationException;
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface IRuleCheckService {
@@ -28,6 +28,6 @@ public interface IRuleCheckService {
      * @throws SubscriptionValidationException 
      */
     String prepareAggregatedObject(JSONArray listRulesJson, JSONArray listEventsJson)
-            throws JSONException, JsonProcessingException, IOException, SubscriptionValidationException;
+            throws JSONException, JsonProcessingException, IOException, MongoDBConnectionException;
 
 }

--- a/src/main/java/com/ericsson/ei/services/IRuleCheckService.java
+++ b/src/main/java/com/ericsson/ei/services/IRuleCheckService.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.json.JSONArray;
 import org.json.JSONException;
 
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface IRuleCheckService {
@@ -24,8 +25,9 @@ public interface IRuleCheckService {
      * @throws JSONException
      * @throws JsonProcessingException
      * @throws IOException
+     * @throws SubscriptionValidationException 
      */
     String prepareAggregatedObject(JSONArray listRulesJson, JSONArray listEventsJson)
-            throws JSONException, JsonProcessingException, IOException;
+            throws JSONException, JsonProcessingException, IOException, SubscriptionValidationException;
 
 }

--- a/src/main/java/com/ericsson/ei/services/RuleCheckService.java
+++ b/src/main/java/com/ericsson/ei/services/RuleCheckService.java
@@ -1,5 +1,6 @@
 package com.ericsson.ei.services;
 
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.EventHandler;
 import com.ericsson.ei.handlers.EventToObjectMapHandler;
@@ -35,7 +36,7 @@ public class RuleCheckService implements IRuleCheckService {
 
     @Override
     public String prepareAggregatedObject(JSONArray listRulesJson, JSONArray listEventsJson)
-            throws JSONException, IOException, SubscriptionValidationException {
+            throws JSONException, IOException, MongoDBConnectionException {
         eventHandler.getRulesHandler().setParsedJson(listRulesJson.toString());
         String response;
         // Looping all events and add suffix template name to id and links, For

--- a/src/main/java/com/ericsson/ei/services/RuleCheckService.java
+++ b/src/main/java/com/ericsson/ei/services/RuleCheckService.java
@@ -46,15 +46,10 @@ public class RuleCheckService implements IRuleCheckService {
             String templateName = jmesPathInterface
                     .runRuleOnEvent("TemplateName", listRulesJson.getJSONObject(i).toString()).asText("TEST");
             templateNames.add(templateName);
-            if (templateNames.size() == 1) {
-                addTemplateNameToIds(listEventsJson.getJSONObject(i), templateName);
-                try {
-                    LOGGER.debug("Event to prepare aggregated object :: {}", listEventsJson.getJSONObject(i).toString());
-                } catch (Exception e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                }
-                eventHandler.eventReceived(listEventsJson.getJSONObject(i).toString());
+			if (templateNames.size() == 1) {
+				addTemplateNameToIds(listEventsJson.getJSONObject(i), templateName);
+				LOGGER.debug("Event to prepare aggregated object :: {}", listEventsJson.getJSONObject(i).toString());
+				eventHandler.eventReceived(listEventsJson.getJSONObject(i).toString());
             }
         }
         String templateName = templateNames.iterator().next();

--- a/src/main/java/com/ericsson/ei/services/RuleCheckService.java
+++ b/src/main/java/com/ericsson/ei/services/RuleCheckService.java
@@ -46,10 +46,10 @@ public class RuleCheckService implements IRuleCheckService {
             String templateName = jmesPathInterface
                     .runRuleOnEvent("TemplateName", listRulesJson.getJSONObject(i).toString()).asText("TEST");
             templateNames.add(templateName);
-			if (templateNames.size() == 1) {
-				addTemplateNameToIds(listEventsJson.getJSONObject(i), templateName);
-				LOGGER.debug("Event to prepare aggregated object :: {}", listEventsJson.getJSONObject(i).toString());
-				eventHandler.eventReceived(listEventsJson.getJSONObject(i).toString());
+            if (templateNames.size() == 1) {
+                addTemplateNameToIds(listEventsJson.getJSONObject(i), templateName);
+                LOGGER.debug("Event to prepare aggregated object :: {}", listEventsJson.getJSONObject(i).toString());
+                eventHandler.eventReceived(listEventsJson.getJSONObject(i).toString());
             }
         }
         String templateName = templateNames.iterator().next();

--- a/src/main/java/com/ericsson/ei/services/RuleCheckService.java
+++ b/src/main/java/com/ericsson/ei/services/RuleCheckService.java
@@ -1,5 +1,6 @@
 package com.ericsson.ei.services;
 
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.EventHandler;
 import com.ericsson.ei.handlers.EventToObjectMapHandler;
 import com.ericsson.ei.jmespath.JmesPathInterface;
@@ -34,7 +35,7 @@ public class RuleCheckService implements IRuleCheckService {
 
     @Override
     public String prepareAggregatedObject(JSONArray listRulesJson, JSONArray listEventsJson)
-            throws JSONException, IOException {
+            throws JSONException, IOException, SubscriptionValidationException {
         eventHandler.getRulesHandler().setParsedJson(listRulesJson.toString());
         String response;
         // Looping all events and add suffix template name to id and links, For
@@ -46,7 +47,12 @@ public class RuleCheckService implements IRuleCheckService {
             templateNames.add(templateName);
             if (templateNames.size() == 1) {
                 addTemplateNameToIds(listEventsJson.getJSONObject(i), templateName);
-                LOGGER.debug("Event to prepare aggregated object :: {}", listEventsJson.getJSONObject(i).toString());
+                try {
+                    LOGGER.debug("Event to prepare aggregated object :: {}", listEventsJson.getJSONObject(i).toString());
+                } catch (Exception e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
                 eventHandler.eventReceived(listEventsJson.getJSONObject(i).toString());
             }
         }

--- a/src/main/java/com/ericsson/ei/services/RuleCheckService.java
+++ b/src/main/java/com/ericsson/ei/services/RuleCheckService.java
@@ -1,7 +1,6 @@
 package com.ericsson.ei.services;
 
 import com.ericsson.ei.exception.MongoDBConnectionException;
-import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.EventHandler;
 import com.ericsson.ei.handlers.EventToObjectMapHandler;
 import com.ericsson.ei.jmespath.JmesPathInterface;

--- a/src/main/java/com/ericsson/ei/utils/MongoDBMonitorThread.java
+++ b/src/main/java/com/ericsson/ei/utils/MongoDBMonitorThread.java
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 Ericsson AB.
+For a full list of individual contributors, please see the commit history.
+
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.ericsson.ei.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.ericsson.ei.handlers.MongoDBHandler;
+
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class MongoDBMonitorThread extends Thread {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBMonitorThread.class);
+
+	@Autowired
+	MongoDBHandler mongoDBHandler;
+
+	private static boolean isMongoDBConnected = false;
+
+	@Value("${spring.data.mongodb.database}")
+	private String dataBaseName;
+
+	@Override
+	public void run() {
+		while (!isMongoDBConnected) {
+			try {
+				Thread.sleep(30000);
+				isMongoDBConnected = mongoDBHandler.checkMongoDbStatus(dataBaseName);
+				setMongoDBConnected(isMongoDBConnected);
+				LOGGER.info(" monitor the mongoDB connection for every 30sec...");
+			} catch (Exception e) {
+				LOGGER.error("Exception creating connection to MongoDB " + e);
+			}
+		}
+	}
+
+	public static boolean isMongoDBConnected() {
+		return isMongoDBConnected;
+	}
+
+	public static void setMongoDBConnected(boolean isMongoDBConnected) {
+		MongoDBMonitorThread.isMongoDBConnected = isMongoDBConnected;
+	}
+}

--- a/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
+++ b/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
@@ -17,6 +17,7 @@
 package com.ericsson.ei.waitlist;
 
 import com.ericsson.ei.jmespath.JmesPathInterface;
+import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.rules.RulesObject;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -67,8 +68,9 @@ public class WaitListStorageHandler {
      *
      * @param event The event that will be added to database
      * @param rulesObject Rules for extracting a unique identifier from an event object to be used as document id
+     * @throws SubscriptionValidationException 
      */
-    public void addEventToWaitListIfNotExisting(String event, RulesObject rulesObject) {
+    public void addEventToWaitListIfNotExisting(String event, RulesObject rulesObject) throws SubscriptionValidationException {
         try {
             JsonNode id = extractIdFromEventUsingRules(event, rulesObject);
             String foundEvent = findEventInWaitList(id.textValue());
@@ -100,7 +102,7 @@ public class WaitListStorageHandler {
         return mongoDbHandler.getAllDocuments(databaseName, collectionName);
     }
 
-    private BasicDBObject createWaitListDocument(String event, JsonNode id, Date date) {
+    private BasicDBObject createWaitListDocument(String event, JsonNode id, Date date) throws SubscriptionValidationException {
         BasicDBObject document = new BasicDBObject();
         document.put("_id", id.textValue());
         document.put("Time", date);

--- a/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
+++ b/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
@@ -18,7 +18,6 @@ package com.ericsson.ei.waitlist;
 
 import com.ericsson.ei.jmespath.JmesPathInterface;
 import com.ericsson.ei.exception.MongoDBConnectionException;
-import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.rules.RulesObject;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -69,7 +68,7 @@ public class WaitListStorageHandler {
      *
      * @param event The event that will be added to database
      * @param rulesObject Rules for extracting a unique identifier from an event object to be used as document id
-     * @throws SubscriptionValidationException 
+     * @throws MongoDBConnectionException 
      */
     public void addEventToWaitListIfNotExisting(String event, RulesObject rulesObject) throws MongoDBConnectionException {
         try {

--- a/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
+++ b/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
@@ -17,6 +17,7 @@
 package com.ericsson.ei.waitlist;
 
 import com.ericsson.ei.jmespath.JmesPathInterface;
+import com.ericsson.ei.exception.MongoDBConnectionException;
 import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.rules.RulesObject;
@@ -70,7 +71,7 @@ public class WaitListStorageHandler {
      * @param rulesObject Rules for extracting a unique identifier from an event object to be used as document id
      * @throws SubscriptionValidationException 
      */
-    public void addEventToWaitListIfNotExisting(String event, RulesObject rulesObject) throws SubscriptionValidationException {
+    public void addEventToWaitListIfNotExisting(String event, RulesObject rulesObject) throws MongoDBConnectionException {
         try {
             JsonNode id = extractIdFromEventUsingRules(event, rulesObject);
             String foundEvent = findEventInWaitList(id.textValue());
@@ -102,7 +103,7 @@ public class WaitListStorageHandler {
         return mongoDbHandler.getAllDocuments(databaseName, collectionName);
     }
 
-    private BasicDBObject createWaitListDocument(String event, JsonNode id, Date date) throws SubscriptionValidationException {
+    private BasicDBObject createWaitListDocument(String event, JsonNode id, Date date) throws MongoDBConnectionException {
         BasicDBObject document = new BasicDBObject();
         document.put("_id", id.textValue());
         document.put("Time", date);

--- a/src/test/java/com/ericsson/ei/handlers/test/MongoDBHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/handlers/test/MongoDBHandlerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.test.utils.TestConfigs;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoTimeoutException;
 
 public class MongoDBHandlerTest {
 
@@ -38,6 +40,7 @@ public class MongoDBHandlerTest {
 
     private MongoDBHandler mongoDBHandler;
 
+    private MongoClient mongoClient;
     private String dataBaseName = "MongoDBHandlerTestDB";
     private String collectionName = "SampleEvents";
     private String mapCollectionName = "SampleEventObjectMap";
@@ -101,8 +104,15 @@ public class MongoDBHandlerTest {
     @Test
     public void checkMongoDBStatusDown() {
         final MongoDBHandler mongoDB = new MongoDBHandler();
+        //List<String> collectionList = mongoClient.getDatabase(dataBaseName).listCollectionNames().into(new ArrayList<String>());
+        Mockito.when(mongoClient.getDatabase(dataBaseName).listCollectionNames().into(new ArrayList<String>())).thenThrow(new Exception("MongoCommandException, Something went wrong with MongoDb connection"));
+        assertEquals(mongoDB.checkMongoDbStatus(dataBaseName),false);
+    }
+    
+    @Test
+    public void checkMongoDBStatusDown1() {
+        final MongoDBHandler mongoDB = new MongoDBHandler();
         final MongoClient mongoclient = null;
-        Mockito.when(mongoclient.getDatabase(dataBaseName)).thenReturn(null);
         assertEquals(mongoDB.checkMongoDbStatus(dataBaseName),false);
     }
 }

--- a/src/test/java/com/ericsson/ei/handlers/test/MongoDBHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/handlers/test/MongoDBHandlerTest.java
@@ -16,6 +16,7 @@
 */
 package com.ericsson.ei.handlers.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -23,11 +24,13 @@ import java.util.ArrayList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.ericsson.ei.handlers.MongoDBHandler;
 import com.ericsson.ei.test.utils.TestConfigs;
+import com.mongodb.MongoClient;
 
 public class MongoDBHandlerTest {
 
@@ -88,5 +91,18 @@ public class MongoDBHandlerTest {
     @Test
     public void updateEventToObjectMap() {
     	assertTrue(mongoDBHandler.updateDocumentAddToSet(dataBaseName, mapCollectionName, conditionForEventToObjectMap, updateInputForEventToObjectMap));
+    }
+    
+    @Test
+    public void checkMongoDBStatusUp() {
+        assertTrue(mongoDBHandler.checkMongoDbStatus(dataBaseName));
+    }
+
+    @Test
+    public void checkMongoDBStatusDown() {
+        final MongoDBHandler mongoDB = new MongoDBHandler();
+        final MongoClient mongoclient = null;
+        Mockito.when(mongoclient.getDatabase(dataBaseName)).thenReturn(null);
+        assertEquals(mongoDB.checkMongoDbStatus(dataBaseName),false);
     }
 }

--- a/src/test/java/com/ericsson/ei/handlers/test/MongoDBHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/handlers/test/MongoDBHandlerTest.java
@@ -98,21 +98,13 @@ public class MongoDBHandlerTest {
     
     @Test
     public void checkMongoDBStatusUp() {
-        assertTrue(mongoDBHandler.checkMongoDbStatus(dataBaseName));
+        assertEquals(mongoDBHandler.checkMongoDbStatus(dataBaseName), true);
     }
 
     @Test
     public void checkMongoDBStatusDown() {
         final MongoDBHandler mongoDB = new MongoDBHandler();
-        //List<String> collectionList = mongoClient.getDatabase(dataBaseName).listCollectionNames().into(new ArrayList<String>());
-        Mockito.when(mongoClient.getDatabase(dataBaseName).listCollectionNames().into(new ArrayList<String>())).thenThrow(new Exception("MongoCommandException, Something went wrong with MongoDb connection"));
-        assertEquals(mongoDB.checkMongoDbStatus(dataBaseName),false);
-    }
-    
-    @Test
-    public void checkMongoDBStatusDown1() {
-        final MongoDBHandler mongoDB = new MongoDBHandler();
         final MongoClient mongoclient = null;
-        assertEquals(mongoDB.checkMongoDbStatus(dataBaseName),false);
+        assertEquals(mongoDB.checkMongoDbStatus(dataBaseName), false);
     }
 }


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
Provided the fix for handling the long message queue issue when the mongoDB connection is down.
As a part of this implementation,  during the events publishing if the MongDB is down, a monitor thread will start and it will check DB connection status for every 30 seconds once the DB connection is up events will starts for consuming

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Queued events will be redelivered once the mongoDB connection is Re-established. 
No need to restart the EI-backend component

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Sudharshan bandaru sudharshan.b@tcs.com, durga.vasaadi@tcs.com
