### PR TITLE
Implemented changes for shallow behavior in EIB

### DIFF
--- a/src/integrationtests/resources/application.properties
+++ b/src/integrationtests/resources/application.properties
@@ -59,7 +59,7 @@ spring.mail.properties.mail.smtp.auth: false
 spring.mail.properties.mail.smtp.starttls.enable: false
 
 event.repository.url: http://localhost:8084/search/
-event.repository.shallow:true
+event.repository.shallow: true
 
 ldap.enabled: false
 ldap.server.list: [{\

--- a/src/integrationtests/resources/application.properties
+++ b/src/integrationtests/resources/application.properties
@@ -59,6 +59,7 @@ spring.mail.properties.mail.smtp.auth: false
 spring.mail.properties.mail.smtp.starttls.enable: false
 
 event.repository.url: http://localhost:8084/search/
+event.repository.shallow:true
 
 ldap.enabled: false
 ldap.server.list: [{\

--- a/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
+++ b/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
@@ -54,7 +54,7 @@ public class ERQueryService {
     private String eventRepositoryUrl;
 
     @Getter
-    @Value("${event.repository.shallow}")
+    @Value("${event.repository.shallow:true}")
     private Boolean shallow;
 
     public ERQueryService() {

--- a/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
+++ b/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
@@ -104,12 +104,12 @@ public class ERQueryService {
 
     private void prepareRequest(String eventId, SearchOption searchOption, int limit,
             int levels, boolean tree) throws IOException, URISyntaxException {
-        Boolean shallowParamter;
+        Boolean shallowParameter;
         if (shallow == null ) {
-            shallowParamter = true;
+            shallowParameter = true;
         }
         else {
-            shallowParamter = shallow;
+            shallowParameter = shallow;
         }
         final SearchParameters searchParameters = getSearchParameters(searchOption);
         request
@@ -119,7 +119,7 @@ public class ERQueryService {
                .addParam("limit", Integer.toString(limit))
                .addParam("levels", Integer.toString(levels))
                .addParam("tree", Boolean.toString(tree))
-               .addParam("shallow", Boolean.toString(shallowParamter))
+               .addParam("shallow", Boolean.toString(shallowParameter))
                .setBody(searchParameters.getAsJsonString(), ContentType.APPLICATION_JSON);
 
         String uri = request.getURI().toString();

--- a/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
+++ b/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
@@ -53,6 +53,10 @@ public class ERQueryService {
     @Value("${event.repository.url}")
     private String eventRepositoryUrl;
 
+    @Getter
+    @Value("${event.repository.shallow}")
+    private String shallowParameter;
+
     public ERQueryService() {
         this.request = new HttpRequest();
     }
@@ -100,7 +104,14 @@ public class ERQueryService {
 
     private void prepareRequest(String eventId, SearchOption searchOption, int limit,
             int levels, boolean tree) throws IOException, URISyntaxException {
+        String shallow="";
         final SearchParameters searchParameters = getSearchParameters(searchOption);
+        if (shallowParameter == null || shallowParameter.isEmpty()) {
+            shallow ="true";
+        }
+        else {
+            shallow = shallowParameter;
+        }
         request
                .setHttpMethod(HttpMethod.POST)
                .setBaseUrl(eventRepositoryUrl)
@@ -108,6 +119,7 @@ public class ERQueryService {
                .addParam("limit", Integer.toString(limit))
                .addParam("levels", Integer.toString(levels))
                .addParam("tree", Boolean.toString(tree))
+               .addParam("shallow", shallow)
                .setBody(searchParameters.getAsJsonString(), ContentType.APPLICATION_JSON);
 
         String uri = request.getURI().toString();

--- a/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
+++ b/src/main/java/com/ericsson/ei/erqueryservice/ERQueryService.java
@@ -55,7 +55,7 @@ public class ERQueryService {
 
     @Getter
     @Value("${event.repository.shallow}")
-    private String shallowParameter;
+    private Boolean shallow;
 
     public ERQueryService() {
         this.request = new HttpRequest();
@@ -104,14 +104,14 @@ public class ERQueryService {
 
     private void prepareRequest(String eventId, SearchOption searchOption, int limit,
             int levels, boolean tree) throws IOException, URISyntaxException {
-        String shallow="";
-        final SearchParameters searchParameters = getSearchParameters(searchOption);
-        if (shallowParameter == null || shallowParameter.isEmpty()) {
-            shallow ="true";
+        Boolean shallowParamter;
+        if (shallow == null ) {
+            shallowParamter = true;
         }
         else {
-            shallow = shallowParameter;
+            shallowParamter = shallow;
         }
+        final SearchParameters searchParameters = getSearchParameters(searchOption);
         request
                .setHttpMethod(HttpMethod.POST)
                .setBaseUrl(eventRepositoryUrl)
@@ -119,7 +119,7 @@ public class ERQueryService {
                .addParam("limit", Integer.toString(limit))
                .addParam("levels", Integer.toString(levels))
                .addParam("tree", Boolean.toString(tree))
-               .addParam("shallow", shallow)
+               .addParam("shallow", Boolean.toString(shallowParamter))
                .setBody(searchParameters.getAsJsonString(), ContentType.APPLICATION_JSON);
 
         String uri = request.getURI().toString();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,7 +58,7 @@ spring.mail.properties.mail.smtp.auth: false
 spring.mail.properties.mail.smtp.starttls.enable: false
 
 event.repository.url:
-event.repository.shallow:true
+event.repository.shallow: true
 
 ldap.enabled: false
 ldap.server.list: [{\

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,6 +58,7 @@ spring.mail.properties.mail.smtp.auth: false
 spring.mail.properties.mail.smtp.starttls.enable: false
 
 event.repository.url:
+event.repository.shallow:
 
 ldap.enabled: false
 ldap.server.list: [{\

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,7 +58,7 @@ spring.mail.properties.mail.smtp.auth: false
 spring.mail.properties.mail.smtp.starttls.enable: false
 
 event.repository.url:
-event.repository.shallow:
+event.repository.shallow:true
 
 ldap.enabled: false
 ldap.server.list: [{\

--- a/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
+++ b/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
@@ -71,6 +71,7 @@ public class ERQueryServiceTest extends Mockito {
     private int limitParam = 85;
     private int levels = 2;
     private boolean isTree = true;
+    private boolean shallow = true;
 
     @Before
     public void setUp() throws Exception {
@@ -101,8 +102,8 @@ public class ERQueryServiceTest extends Mockito {
     }
 
     public String buildUri() {
-        String uri = String.format("%s%s?limit=%s&tree=%s&levels=%s",
-                erQueryService.getEventRepositoryUrl().trim(), eventId, limitParam, isTree, levels);
+        String uri = String.format("%s%s?limit=%s&tree=%s&shallow=%s&levels=%s",
+                erQueryService.getEventRepositoryUrl().trim(), eventId, limitParam, isTree, shallow, levels) ;
         return uri;
     }
 }

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -159,6 +159,14 @@ used. **event.repository.url** takes a full URL to such a repository.
 
 * event.repository.url
 
+A shallow property has been added , which is set to true. With property **event.repository.shallow** set to true,
+the ER query from Eiffel Intelligence will search the event id only in main ER. It will not look in external ER(s)
+for event ids. If this parameter set to false , search for event id will extended to External ER(s) as well.
+
+The event id is of aggregated object. Using this event id , ER query will retrieve upstream/downstream events.
+
+* event.repository.shallow
+
 ## MongoDB
 
 You can set up connections to a single MongoDB instance or a Replica set of multiple MongoDB instances with or


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
Implemented changes for shallow behavior in EIB

### Description of the Change
Providing shallow parameter as true by default in EI-Backend , will limit the ER query from EIB to search for upstream/downstream events in main ER only. Search will not be navigated to external ER(s). Configurable parameter **event.repository.shallow** added in application.properties to support these changes.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Rishav-kumar rishav.kumar3@tcs.com
