### PR TITLE
EI Frontend clogged when old subscriptions are not removed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.ericsson</groupId>
     <artifactId>eiffel-intelligence</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.4</version>
     <packaging>war</packaging>
 
     <parent>

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
@@ -19,8 +19,12 @@ package com.ericsson.ei.notifications;
 import com.ericsson.ei.exception.AuthenticationException;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.time.Duration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -38,8 +42,10 @@ public class HttpRequestSender {
 
     private RestOperations rest;
     
-    public HttpRequestSender(RestTemplateBuilder builder) {
-        rest = builder.build();
+    @Autowired
+    public HttpRequestSender(RestTemplateBuilder builder, @Value("${notification.httpRequest.timeout:5000}") Duration timeOut) {
+        timeOut = timeOut == null ? Duration.ofMillis(5000) : timeOut;
+        rest = builder.setReadTimeout(timeOut).setConnectTimeout(timeOut).build();
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,6 +46,7 @@ waitlist.resend.fixed.rate: 15000
 failed.notifications.collection.name: failed_notifications
 failed.notifications.collection.ttl: 600
 notification.retry: 3
+notification.httpRequest.timeout: 5000
 
 email.sender: noreply@domain.com
 email.subject: Email Subscription Notification

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -156,10 +156,13 @@ Eiffel Intelligence how long a failed notification will be stored in the
 database before deletion. With **notification.retry** property, it
 is possible to configure the number of attempts Eiffel Intelligence will
 retry to make a REST POST notification when a subscription is triggered.
+The **notification.httpRequest.timeout** property value will be used to set the
+response timeout for the Rest Post notifications when a subscription is triggered.
 
 * failed.notifications.collection.name
 * failed.notifications.collection.ttl
 * notification.retry
+* notification.httpRequest.timeout
 
 ### Configure Search in Event Repository
 


### PR DESCRIPTION
Implementation is done to handle EI Frontend clogged when old subscriptions are not removed.

### Applicable Issues

### Description of the Change
When the REST Endpoints are unresponsive the subscriptions are blocked by it (currently it takes around 2 mins to check the response and retry) and the application eventually becomes unresponsive.
To avoid this we have introduced a timeout value which can be configured using the application properties instead of depending on http default values

### Alternate Designs

### Benefits
EI Frontend has a customized timeout from which we can get fast responses from the Rest Post notifications when a subscription is triggered.

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Raju Beemreddy raju.beemreddy@tcs.com, Gangisetty Alekhya gangisetty.alekhya@tcs.com
