### PR TITLE
EI Documentation update regarding API Token usage in Jenkins authentication for subscription

### DIFF
--- a/wiki/triggering-jenkins-jobs.md
+++ b/wiki/triggering-jenkins-jobs.md
@@ -28,6 +28,9 @@ authentication type works. BASIC_AUTH can also be used.
 ### userName & password
 The username and password Eiffel Intelligence will use in headers of the HTTP 
 request when sending a notification via HTTP POST.
+As improved CSRF protection provided since Jenkins version 2.176.2, it is recommended that to set this Password/Token field
+as an API token and not Jenkins user password. Click [here](https://www.jenkins.io/doc/upgrade-guide/2.176/#SECURITY-626)
+to see Jenkins upgrade guides regarding this improvement.
 
 ### notificationMeta
 Which url to use for the HTTP POST request. This url contains parameters to 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
Subscription notification getting missed for Jenkins job trigger due to 403 invalid crumb exception.

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Updated documentation with below details.
As improved CSRF protection provided since Jenkins version 2.176.2, it is recommended that to set this Password/Token field as an API token and not Jenkins user password.

### Benefits
It will provide improved CSRF protection to trigger Jenkins job by subscription notification.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Improved CSRF protection provided since Jenkins version 2.176.2, there are chances of subscription notifications getting missed with 403 exception due to session id check in case of Jenkins user password used in subscriptions.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Dhruvin Kalavadia <dhruvin.kalavadia@tcs.com>
